### PR TITLE
Add noasm build tag

### DIFF
--- a/asm/daxpy.go
+++ b/asm/daxpy.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64
+//+build !amd64 noasm
 
 package asm
 

--- a/asm/daxpy_amd64.go
+++ b/asm/daxpy_amd64.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//+build !noasm
+
 package asm
 
 func DaxpyUnitary(alpha float64, x, y []float64)

--- a/asm/daxpy_amd64.s
+++ b/asm/daxpy_amd64.s
@@ -34,6 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+//+build !noasm
 
 // TODO(fhs): use textflag.h after we drop Go 1.3 support
 //#include "textflag.h"

--- a/asm/ddot.go
+++ b/asm/ddot.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !amd64
+//+build !amd64 noasm
 
 package asm
 

--- a/asm/ddot_amd64.go
+++ b/asm/ddot_amd64.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//+build !noasm
+
 package asm
 
 func DdotUnitary(x, y []float64) (sum float64)

--- a/asm/ddot_amd64.s
+++ b/asm/ddot_amd64.s
@@ -34,6 +34,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+//+build !noasm
 
 // TODO(fhs): use textflag.h after we drop Go 1.3 support
 //#include "textflag.h"


### PR DESCRIPTION
This allows easy benchmarking against the pure pure Go implementation and also provides a way to easily assess compiler improvements.

e.g.

```
$ cd $GOPATH/src/github.com/gonum/blas/native
$ go test -bench . > asm.txt
$ go test -tags noasm -bench . > noasm.txt
$ benchcmp noasm.txt asm.txt
```
