### PR TITLE
Add AMD64 SSE slice operations

### DIFF
--- a/asm/dslice.go
+++ b/asm/dslice.go
@@ -11,9 +11,9 @@ import (
 // Div64 divides two slices
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil
-// len64(out)  == len(a) == len(b)
+// len(out)  == len(a) == len(b)
 func Div64(out, a, b []float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = a[i] / b[i]
 	}
 }
@@ -21,9 +21,9 @@ func Div64(out, a, b []float64) {
 // Add64 adds two slices
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil
-// len64(out)  == len(a) == len(b)
+// len(out)  == len(a) == len(b)
 func Add64(out, a, b []float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = a[i] + b[i]
 	}
 }
@@ -31,9 +31,9 @@ func Add64(out, a, b []float64) {
 // Sub64 subtracts two slices
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil
-// len64(out)  == len(a) == len(b)
+// len(out)  == len(a) == len(b)
 func Sub64(out, a, b []float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = a[i] - b[i]
 	}
 }
@@ -41,9 +41,9 @@ func Sub64(out, a, b []float64) {
 // Mul64 multiply two slices
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil
-// len64(out)  == len(a) == len(b)
+// len(out)  == len(a) == len(b)
 func Mul64(out, a, b []float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = a[i] * b[i]
 	}
 }
@@ -51,9 +51,9 @@ func Mul64(out, a, b []float64) {
 // Min64 returns lowest valus of two slices
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil
-// len64(out)  == len(a) == len(b)
+// len(out)  == len(a) == len(b)
 func Min64(out, a, b []float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		if a[i] < b[i] {
 			out[i] = a[i]
 		} else {
@@ -65,9 +65,9 @@ func Min64(out, a, b []float64) {
 // Max64 return maximum of two slices
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil
-// len64(out)  == len(a) == len(b)
+// len(out)  == len(a) == len(b)
 func Max64(out, a, b []float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		if a[i] > b[i] {
 			out[i] = a[i]
 		} else {
@@ -80,10 +80,10 @@ func Max64(out, a, b []float64) {
 // for each element in the slice.
 // Assumptions the assembly can make:
 // out != nil, a != nil, b != nil
-// len64(out)  == len(a) == len(b)
+// len(out)  == len(a) == len(b)
 func ChangeSign64(out, a, b []float64) {
 	const sign = 1 << 63
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = math.Float64frombits(math.Float64bits(a[i])&^sign | math.Float64bits(b[i])&sign)
 
 	}
@@ -92,9 +92,9 @@ func ChangeSign64(out, a, b []float64) {
 // ConstDiv64 will return c / values of the array
 // Assumptions the assembly can make:
 // out != nil, a != nil
-// len64(out)  == len(a)
+// len(out)  == len(a)
 func ConstDiv64(out, a []float64, c float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = c / a[i]
 	}
 }
@@ -102,9 +102,9 @@ func ConstDiv64(out, a []float64, c float64) {
 // ConstMul64 will return c * values of the array
 // Assumptions the assembly can make:
 // out != nil, a != nil
-// len64(out)  == len(a)
+// len(out)  == len(a)
 func ConstMul64(out, a []float64, c float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = c * a[i]
 	}
 }
@@ -112,9 +112,9 @@ func ConstMul64(out, a []float64, c float64) {
 // ConstAdd64 will return c * values of the array
 // Assumptions the assembly can make:
 // out != nil, a != nil
-// len64(out)  == len(a)
+// len(out)  == len(a)
 func ConstAdd64(out, a []float64, c float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = c + a[i]
 	}
 }
@@ -133,9 +133,9 @@ func AddScaled64(y, x []float64, a float64) {
 // Sqrt64 will return math.Sqrt(values) of the array
 // Assumptions the assembly can make:
 // out != nil, a != nil
-// len64(out)  == len(a)
+// len(out)  == len(a)
 func Sqrt64(out, a []float64) {
-	for i := 0; i < len64(out); i++ {
+	for i := 0; i < len(out); i++ {
 		out[i] = float64(math.Sqrt(float64(a[i])))
 	}
 }
@@ -183,7 +183,7 @@ func Sum64(a []float64) float64 {
 // Abs64 will return math.Abs(values) of the array
 // Assumptions the assembly can make:
 // out != nil, a != nil
-// len64(out)  == len(a)
+// len(out)  == len(a)
 func Abs64(out, a []float64) {
 	for i, v := range a {
 		out[i] = float64(math.Abs(float64(v)))

--- a/asm/dslice.go
+++ b/asm/dslice.go
@@ -1,0 +1,191 @@
+// +build !amd64 noasm
+
+package asm
+
+import (
+	"math"
+)
+
+// These are the fallbacks that are used when not on AMD64 platform.
+
+// Div64 divides two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len64(out)  == len(a) == len(b)
+func Div64(out, a, b []float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = a[i] / b[i]
+	}
+}
+
+// Add64 adds two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len64(out)  == len(a) == len(b)
+func Add64(out, a, b []float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = a[i] + b[i]
+	}
+}
+
+// Sub64 subtracts two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len64(out)  == len(a) == len(b)
+func Sub64(out, a, b []float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = a[i] - b[i]
+	}
+}
+
+// Mul64 multiply two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len64(out)  == len(a) == len(b)
+func Mul64(out, a, b []float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = a[i] * b[i]
+	}
+}
+
+// Min64 returns lowest valus of two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len64(out)  == len(a) == len(b)
+func Min64(out, a, b []float64) {
+	for i := 0; i < len64(out); i++ {
+		if a[i] < b[i] {
+			out[i] = a[i]
+		} else {
+			out[i] = b[i]
+		}
+	}
+}
+
+// Max64 return maximum of two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len64(out)  == len(a) == len(b)
+func Max64(out, a, b []float64) {
+	for i := 0; i < len64(out); i++ {
+		if a[i] > b[i] {
+			out[i] = a[i]
+		} else {
+			out[i] = b[i]
+		}
+	}
+}
+
+// ChangeSign64 returns a value with the magnitude of a and the sign of b
+// for each element in the slice.
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len64(out)  == len(a) == len(b)
+func ChangeSign64(out, a, b []float64) {
+	const sign = 1 << 63
+	for i := 0; i < len64(out); i++ {
+		out[i] = math.Float64frombits(math.Float64bits(a[i])&^sign | math.Float64bits(b[i])&sign)
+
+	}
+}
+
+// ConstDiv64 will return c / values of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len64(out)  == len(a)
+func ConstDiv64(out, a []float64, c float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = c / a[i]
+	}
+}
+
+// ConstMul64 will return c * values of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len64(out)  == len(a)
+func ConstMul64(out, a []float64, c float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = c * a[i]
+	}
+}
+
+// ConstAdd64 will return c * values of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len64(out)  == len(a)
+func ConstAdd64(out, a []float64, c float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = c + a[i]
+	}
+}
+
+// AddScaled64 adds a scaled narray elementwise.
+// y = y + a * x
+// Assumptions the assembly can make:
+// y != nil, a != nil
+// len(x)  == len(y)
+func AddScaled64(y, x []float64, a float64) {
+	for i, v := range x {
+		y[i] += v * a
+	}
+}
+
+// Sqrt64 will return math.Sqrt(values) of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len64(out)  == len(a)
+func Sqrt64(out, a []float64) {
+	for i := 0; i < len64(out); i++ {
+		out[i] = float64(math.Sqrt(float64(a[i])))
+	}
+}
+
+// MinElement64 will the smallest value of the slice
+// Assumptions the assembly can make:
+// a != nil
+// len(a) > 0
+func MinElement64(a []float64) float64 {
+	min := a[0]
+	for i := 1; i < len(a); i++ {
+		if a[i] < min {
+			min = a[i]
+		}
+	}
+	return min
+}
+
+// MaxElement64 will the biggest value of the slice
+// Assumptions the assembly can make:
+// a != nil
+// len(a) > 0
+func MaxElement64(a []float64) float64 {
+	max := a[0]
+	for i := 1; i < len(a); i++ {
+		if a[i] > max {
+			max = a[i]
+		}
+	}
+	return max
+}
+
+// Sum64 will return the sum of all elements of the slice
+// Assumptions the assembly can make:
+// a != nil
+// len(a) >= 0
+func Sum64(a []float64) float64 {
+	sum := float64(0.0)
+	for _, v := range a {
+		sum += v
+	}
+	return sum
+}
+
+// Abs64 will return math.Abs(values) of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len64(out)  == len(a)
+func Abs64(out, a []float64) {
+	for i, v := range a {
+		out[i] = float64(math.Abs(float64(v)))
+	}
+}

--- a/asm/dslice_amd64.go
+++ b/asm/dslice_amd64.go
@@ -1,4 +1,4 @@
-// +build amd64 !noasm
+// +build !noasm
 
 package asm
 

--- a/asm/dslice_amd64.go
+++ b/asm/dslice_amd64.go
@@ -1,0 +1,55 @@
+// +build amd64 !noasm
+
+package asm
+
+// These are function definitions for AMD64 optimized routines,
+// and fallback that can be used for performance testing.
+// See function documentation in dslice.go
+
+// approx 2x faster than Go
+func Div64(out, a, b []float64)
+
+// approx 3x faster than Go
+func Add64(out, a, b []float64)
+
+// approx 3x faster than Go
+func Mul64(out, a, b []float64)
+
+// approx 3x faster than Go
+func Sub64(out, a, b []float64)
+
+// approx 4x faster than Go
+func Min64(out, a, b []float64)
+
+// approx 4x faster than Go
+func Max64(out, a, b []float64)
+
+// approx Xx faster than Go
+func ChangeSign64(out, a, b []float64)
+
+// approx 2x faster than Go
+func ConstDiv64(out, a []float64, c float64)
+
+// approx 3x faster than Go
+func ConstMul64(out, a []float64, c float64)
+
+// approx 3x faster than Go
+func ConstAdd64(out, a []float64, c float64)
+
+// approx 3x faster than Go
+func AddScaled64(y, x []float64, a float64)
+
+// approx 2x faster than Go
+func Sqrt64(out, a []float64)
+
+// approx 12x faster than Go
+func Abs64(out, a []float64)
+
+// approx 6x faster than Go
+func MinElement64(a []float64) float64
+
+// approx 6x faster than Go
+func MaxElement64(a []float64) float64
+
+// approx 4x faster than Go
+func SliceSum64(a []float64) float64

--- a/asm/dslice_amd64.s
+++ b/asm/dslice_amd64.s
@@ -1,0 +1,657 @@
+//+build !noasm
+
+// func Div64(out []float64, a []float64, b []float64)
+TEXT ·Div64(SB), 7, $0
+    MOVQ    out+0(FP),SI        // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_div
+loopback_div:
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    DIVPD   X1,X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    DIVPD   X3,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_div
+remain_div:
+    CMPQ    R10,$0
+    JEQ     done_div
+onemore_div:
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    DIVSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_div
+done_div:
+    RET ,
+
+
+// func Sub64(out []float64, a []float64, b []float64)
+TEXT ·Sub64(SB), 7, $0
+    MOVQ    out+0(FP),SI        // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_sub
+loopback_sub:
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    SUBPD   X1,X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    SUBPD   X3,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_sub
+remain_sub:
+    CMPQ    R10,$0
+    JEQ     done_sub
+onemore_sub:
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    SUBSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_sub
+done_sub:
+    RET
+
+// func Mul64(out []float64, a []float64, b []float64)
+TEXT ·Mul64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_mul
+loopback_mul:
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    MULPD   X1,X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    MULPD   X3,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_mul
+remain_mul:
+    CMPQ    R10,$0
+    JEQ     done_mul
+onemore_mul:
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    MULSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_mul
+done_mul:
+    RET ,
+
+
+// func Add64(out []float64, a []float64, b []float64)
+TEXT ·Add64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_add
+loopback_add:
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    ADDPD   X1,X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    ADDPD   X3,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_add
+remain_add:
+    CMPQ    R10,$0
+    JEQ     done_add
+onemore_add:
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    ADDSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_add
+done_add:
+    RET ,
+
+// func Min64(out []float64, a []float64, b []float64)
+TEXT ·Min64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_min
+loopback_min:
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    MINPD   X1,X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    MINPD   X3,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_min
+remain_min:
+    CMPQ    R10,$0
+    JEQ     done_min
+onemore_min:
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    MINSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_min
+done_min:
+    RET ,
+
+// func Max64(out []float64, a []float64, b []float64)
+TEXT ·Max64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_max
+loopback_max:
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    MAXPD   X1,X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    MAXPD   X3,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_max
+remain_max:
+    CMPQ    R10,$0
+    JEQ     done_max
+onemore_max:
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    MAXSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_max
+done_max:
+    RET ,
+
+// func ChangeSign64(out []float64, a []float64, b []float64)
+TEXT ·ChangeSign64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len64(out)
+    MOVQ    $(1<<63), BX
+    MOVQ    BX, X4             // X4: Sign
+    UNPCKLPD X4, X4
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_csign
+loopback_csign:
+	MOVAPD  X4, X5
+	MOVAPD  X4, X6
+    MOVUPD  (R11),X0
+    MOVUPD  (R9),X1
+    MOVUPD  16(R11),X2
+    MOVUPD  16(R9),X3
+    ANDNPD  X0, X5
+    ANDPD   X4, X1
+    ORPD    X5, X1
+
+    ANDNPD  X2, X6
+    ANDPD   X4, X3
+    ORPD    X6, X3
+    MOVUPD  X1,(SI)
+    MOVUPD  X3,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_csign
+remain_csign:
+    CMPQ    R10,$0
+    JEQ     done_csign
+onemore_csign:
+	MOVSD   X4, X5
+    MOVSD   (R11),X0
+    MOVSD   (R9),X1
+    ANDNPD  X0, X5
+    ANDPD   X4, X1
+    ORPD    X5, X1
+    MOVSD   X1,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, R9
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_csign
+done_csign:
+    RET ,
+
+// func ConstDiv64(out []float64, a []float64, c float64)
+TEXT ·ConstDiv64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVSD   c+48(FP),X4         // X4: c
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_cdiv
+    UNPCKLPD X4, X4
+loopback_cdiv:
+    MOVAPD  X4, X1
+    MOVAPD  X4, X3
+    MOVUPD  (R11),X0
+    DIVPD   X0,X1
+    MOVUPD  16(R11),X2
+    DIVPD   X2,X3
+    MOVUPD  X1,(SI)
+    MOVUPD  X3,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_cdiv
+remain_cdiv:
+    CMPQ    R10,$0
+    JEQ     done_cdiv
+onemore_cdiv:
+    MOVAPD  X4, X1
+    MOVSD   (R11),X0
+    DIVSD   X0,X1
+    MOVSD   X1,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_cdiv
+done_cdiv:
+    RET ,
+
+
+// func ConstMul64(out []float64, a []float64, c float64)
+TEXT ·ConstMul64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVSD   c+48(FP),X4         // X4: c
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_cmul
+    UNPCKLPD X4, X4
+loopback_cmul:
+    MOVUPD  (R11),X0
+    MULPD   X4,X0
+    MOVUPD  16(R11),X2
+    MULPD   X4,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_cmul
+remain_cmul:
+    CMPQ    R10,$0
+    JEQ     done_cmul
+onemore_cmul:
+    MOVSD   (R11),X0
+    MULSD   X4,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_cmul
+done_cmul:
+    RET ,
+
+
+// func ConstAdd64(out []float64, a []float64, c float64)
+TEXT ·ConstAdd64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVSD   c+48(FP),X4         // X4: c
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_cadd
+    UNPCKLPD X4, X4
+loopback_cadd:
+    MOVUPD  (R11),X0
+    ADDPD   X4,X0
+    MOVUPD  16(R11),X2
+    ADDPD   X4,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_cadd
+remain_cadd:
+    CMPQ    R10,$0
+    JEQ     done_cadd
+onemore_cadd:
+    MOVSD   (R11),X0
+    ADDSD   X4,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_cadd
+done_cadd:
+    RET ,
+
+
+// func AddScaled64(y []float64, x []float64, a float64)
+TEXT ·AddScaled64(SB), 7, $0
+    MOVQ    y(FP),SI            // SI: &y
+    MOVQ    y_len+8(FP),DX      // DX: len(y)
+    MOVQ    x+24(FP),R11        // R11: &x
+    MOVSD   a+48(FP),X4         // X4: a
+    MOVQ    DX, R10             // R10: len(y)
+    SHRQ    $2, DX              // DX: len(y) / 4
+    ANDQ    $3, R10             // R10: len(y) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_madd
+    UNPCKLPD X4, X4
+loopback_madd:
+    MOVUPD  (R11),X0
+    MOVUPD  (SI), X5
+    MULPD   X4, X0
+    ADDPD   X5, X0
+    MOVUPD  16(R11),X2
+    MOVUPD  16(SI), X6
+    MULPD   X4, X2
+    ADDPD   X6, X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_madd
+remain_madd:
+    CMPQ    R10,$0
+    JEQ     done_madd
+onemore_madd:
+    MOVSD   (R11),X0
+    MOVSD   (SI),X1
+    MULSD   X4,X0
+    ADDSD   X1,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_madd
+done_madd:
+    RET ,
+
+// func Sqrt64(out []float64, a []float64)
+TEXT ·Sqrt64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_sqrt
+loopback_sqrt:
+    MOVUPD  (R11),X0
+    SQRTPD  X0,X0
+    MOVUPD  16(R11),X2
+    SQRTPD  X2,X2
+    MOVUPD  X0,(SI)
+    MOVUPD  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_sqrt
+remain_sqrt:
+    CMPQ    R10,$0
+    JEQ     done_sqrt
+onemore_sqrt:
+    MOVSD   (R11),X0
+    SQRTSD  X0,X0
+    MOVSD   X0,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_sqrt
+done_sqrt:
+    RET ,
+
+// func Abs64(out []float64, a []float64)
+TEXT ·Abs64(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len64(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    $(1<<63), BX
+    MOVQ    BX, X5             // X1: Sign
+    UNPCKLPD X5, X5
+    MOVQ    DX, R10             // R10: len64(out)
+    SHRQ    $2, DX              // DX: len64(out) / 4
+    ANDQ    $3, R10             // R10: len64(out) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_abs
+loopback_abs:
+    MOVAPD  X5, X3
+    MOVAPD  X5, X4
+    MOVUPD  (R11),X0
+    ANDNPD  X0, X3
+    MOVUPD  16(R11),X1
+    ANDNPD  X1, X4
+    MOVUPD  X3,(SI)
+    MOVUPD  X4,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_abs
+remain_abs:
+    CMPQ    R10,$0
+    JEQ     done_abs
+onemore_abs:
+    MOVAPS  X5, X1
+    MOVSD   (R11),X0
+    ANDNPD  X0, X1
+    MOVSD   X1,(SI)
+    ADDQ    $8, R11
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     onemore_abs
+done_abs:
+    RET ,
+
+// func MinElement64(a []float64) float64
+TEXT ·MinElement64(SB), 7, $0
+    MOVQ    a(FP),SI          // SI: &a
+    MOVQ    a_len+8(FP),DX    // DX: len(a)
+    MOVSD   (SI), X0          // Initial value
+    ADDQ    $8, SI
+    SUBQ    $1, DX
+
+    UNPCKLPD X0, X0
+    MOVQ    DX, R10             // R10: len64(out) -1
+    SHRQ    $2, DX              // DX: (len64(out) - 1) / 4
+    ANDQ    $3, R10             // R10: (len64(out) -1 ) % 4
+    MOVAPD  X0, X1
+    CMPQ    DX ,$0
+    JEQ     remain_min_e
+next_min_e:
+    MOVUPD  (SI), X2
+    MOVUPD  16(SI), X3
+    MINPD   X2, X0
+    MINPD   X3, X1
+    ADDQ    $32, SI
+    SUBQ    $1, DX
+    JNZ next_min_e
+    CMPQ    R10, $0
+    JZ      done_min_e
+remain_min_e:
+    MOVSD   (SI), X2
+    MINSD   X2, X0
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     remain_min_e
+done_min_e:
+    MINPD   X1, X0
+    MOVAPD  X0, X2
+    UNPCKHPD X0, X2
+    MINSD   X2, X0
+    MOVSD X0, ret+24(FP)
+    RET ,
+
+
+// func MaxElement64(a []float64) float64
+TEXT ·MaxElement64(SB), 7, $0
+    MOVQ    a(FP),SI          // SI: &a
+    MOVQ    a_len+8(FP),DX    // DX: len(a)
+    MOVSD   (SI), X0          // Initial value
+    ADDQ    $8, SI
+    SUBQ    $1, DX
+
+    UNPCKLPD X0, X0
+    MOVQ    DX, R10             // R10: len64(out) -1
+    SHRQ    $2, DX              // DX: (len64(out) - 1) / 4
+    ANDQ    $3, R10             // R10: (len64(out) -1 ) % 4
+    MOVAPD  X0, X1
+    CMPQ    DX ,$0
+    JEQ     remain_max_e
+next_max_e:
+    MOVUPD  (SI), X2
+    MOVUPD  16(SI), X3
+    MAXPD   X2, X0
+    MAXPD   X3, X1
+    ADDQ    $32, SI
+    SUBQ    $1, DX
+    JNZ next_max_e
+    CMPQ    R10, $0
+    JZ      done_max_e
+remain_max_e:
+    MOVSD   (SI), X2
+    MAXSD   X2, X0
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     remain_max_e
+done_max_e:
+    MAXPD   X1, X0
+    MOVAPD  X0, X2
+    UNPCKHPD X0, X2
+    MAXSD   X2, X0
+    MOVSD X0, ret+24(FP)
+    RET ,
+
+
+
+// func Sum64(a []float64) float64
+TEXT ·Sum64(SB), 7, $0
+    MOVQ    a(FP),SI          // SI: &a
+    MOVQ    a_len+8(FP),DX    // DX: len(a)
+    XORPD   X0, X0            // Initial value
+    XORPD   X1, X1            // Initial value
+
+    MOVQ    DX, R10             // R10: len64(out) -1
+    SHRQ    $2, DX              // DX: (len64(out) - 1) / 4
+    ANDQ    $3, R10             // R10: (len64(out) -1 ) % 4
+    CMPQ    DX ,$0
+    JEQ     remain_sum
+next_sum:
+    MOVUPD  (SI), X2
+    MOVUPD  16(SI), X3
+    ADDPD   X2, X0
+    ADDPD   X3, X1
+    ADDQ    $32, SI
+    SUBQ    $1, DX
+    JNZ     next_sum
+    CMPQ    R10, $0
+    JZ      done_sum
+remain_sum:
+    MOVSD   (SI), X2
+    ADDSD   X2, X0
+    ADDQ    $8, SI
+    SUBQ    $1, R10
+    JNZ     remain_sum
+done_sum:
+    ADDPD   X1, X0
+    MOVAPD  X0, X2
+    UNPCKHPD X0, X2
+    ADDSD   X2, X0
+    MOVSD   X0, ret+24(FP)
+    RET ,
+

--- a/asm/sslice.go
+++ b/asm/sslice.go
@@ -1,0 +1,191 @@
+// +build !amd64 noasm
+
+package asm
+
+import (
+	"math"
+)
+
+// These are the fallbacks that are used when not on AMD64 platform.
+
+// Div32 divides two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func Div32(out, a, b []float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = a[i] / b[i]
+	}
+}
+
+// Add32 adds two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func Add32(out, a, b []float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = a[i] + b[i]
+	}
+}
+
+// Sub32 subtracts two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func Sub32(out, a, b []float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = a[i] - b[i]
+	}
+}
+
+// Mul32 multiply two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func Mul32(out, a, b []float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = a[i] * b[i]
+	}
+}
+
+// Min32 returns lowest valus of two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func Min32(out, a, b []float32) {
+	for i := 0; i < len(out); i++ {
+		if a[i] < b[i] {
+			out[i] = a[i]
+		} else {
+			out[i] = b[i]
+		}
+	}
+}
+
+// Max32 return maximum of two slices
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func Max32(out, a, b []float32) {
+	for i := 0; i < len(out); i++ {
+		if a[i] > b[i] {
+			out[i] = a[i]
+		} else {
+			out[i] = b[i]
+		}
+	}
+}
+
+// ChangeSign32 returns a value with the magnitude of a and the sign of b
+// for each element in the slice.
+// Assumptions the assembly can make:
+// out != nil, a != nil, b != nil
+// len(out)  == len(a) == len(b)
+func ChangeSign32(out, a, b []float32) {
+	const sign = 1 << 31
+	for i := 0; i < len(out); i++ {
+
+		out[i] = math.Float32frombits(math.Float32bits(a[i])&^sign | math.Float32bits(b[i])&sign)
+	}
+}
+
+// ConstDiv32 will return c / values of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len(out)  == len(a)
+func ConstDiv32(out, a []float32, c float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = c / a[i]
+	}
+}
+
+// ConstMul32 will return c * values of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len(out)  == len(a)
+func ConstMul32(out, a []float32, c float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = c * a[i]
+	}
+}
+
+// ConstAdd32 will return c * values of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len(out)  == len(a)
+func ConstAdd32(out, a []float32, c float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = c + a[i]
+	}
+}
+
+// AddScaled32 adds a scaled narray elementwise.
+// y = y + a * x
+// Assumptions the assembly can make:
+// y != nil, a != nil
+// len(x)  == len(y)
+func AddScaled32(y, x []float32, a float32) {
+	for i, v := range x {
+		y[i] += v * a
+	}
+}
+
+// Sqrt32 will return math.Sqrt(values) of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len(out)  == len(a)
+func Sqrt32(out, a []float32) {
+	for i := 0; i < len(out); i++ {
+		out[i] = float32(math.Sqrt(float64(a[i])))
+	}
+}
+
+// MinElement32 will the smallest value of the slice
+// Assumptions the assembly can make:
+// a != nil
+// len(a) > 0
+func MinElement32(a []float32) float32 {
+	min := a[0]
+	for i := 1; i < len(a); i++ {
+		if a[i] < min {
+			min = a[i]
+		}
+	}
+	return min
+}
+
+// MaxElement32 will the biggest value of the slice
+// Assumptions the assembly can make:
+// a != nil
+// len(a) > 0
+func MaxElement32(a []float32) float32 {
+	max := a[0]
+	for i := 1; i < len(a); i++ {
+		if a[i] > max {
+			max = a[i]
+		}
+	}
+	return max
+}
+
+// Sum32 will return the sum of all elements of the slice
+// Assumptions the assembly can make:
+// a != nil
+// len(a) >= 0
+func Sum32(a []float32) float32 {
+	sum := float32(0.0)
+	for _, v := range a {
+		sum += v
+	}
+	return sum
+}
+
+// Abs32 will return math.Abs(values) of the array
+// Assumptions the assembly can make:
+// out != nil, a != nil
+// len(out)  == len(a)
+func Abs32(out, a []float32) {
+	for i, v := range a {
+		out[i] = float32(math.Abs(float64(v)))
+	}
+}

--- a/asm/sslice_amd64.go
+++ b/asm/sslice_amd64.go
@@ -1,4 +1,4 @@
-// +build amd64 !noasm
+// +build !noasm
 
 package asm
 

--- a/asm/sslice_amd64.go
+++ b/asm/sslice_amd64.go
@@ -1,0 +1,55 @@
+// +build amd64 !noasm
+
+package asm
+
+// These are function definitions for AMD64 optimized routines,
+// and fallback that can be used for performance testing.
+// See function documentation in sslice.go
+
+// approx 8x faster than Go
+func Div32(out, a, b []float32)
+
+// approx 8x faster than Go
+func Add32(out, a, b []float32)
+
+// approx 8x faster than Go
+func Mul32(out, a, b []float32)
+
+// approx 8x faster than Go
+func Sub32(out, a, b []float32)
+
+// approx 8x faster than Go
+func Min32(out, a, b []float32)
+
+// approx 8x faster than Go
+func Max32(out, a, b []float32)
+
+// approx Xx faster than Go
+func ChangeSign32(out, a, b []float32)
+
+// approx 4x faster than Go
+func ConstDiv32(out, a []float32, c float32)
+
+// approx 5x faster than Go
+func ConstMul32(out, a []float32, c float32)
+
+// approx 5x faster than Go
+func ConstAdd32(out, a []float32, c float32)
+
+// approx 13x faster than Go
+func AddScaled32(y, x []float32, a float32)
+
+// approx 11x faster than Go
+func Sqrt32(out, a []float32)
+
+// approx 18x faster than Go
+func Abs32(out, a []float32)
+
+// approx 15x faster than Go
+func MinElement32(a []float32) float32
+
+// approx 15x faster than Go
+func MaxElement32(a []float32) float32
+
+// approx 8x faster than Go
+func Sum32(a []float32) float32

--- a/asm/sslice_amd64.s
+++ b/asm/sslice_amd64.s
@@ -1,0 +1,681 @@
+
+//+build !noasm
+
+// func Div32(out []float32, a []float32, b []float32)
+TEXT ·Div32(SB), 7, $0
+    MOVQ    out+0(FP),SI        // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_div
+loopback_div:
+    MOVUPS  (R11),X0
+    MOVUPS  (R9),X1
+    DIVPS   X1,X0
+    MOVUPS  16(R11),X2
+    MOVUPS  16(R9),X3
+    DIVPS   X3,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_div
+remain_div:
+    CMPQ    R10,$0
+    JEQ     done_div
+onemore_div:
+    MOVSS   (R11),X0
+    MOVSS   (R9),X1
+    DIVSS   X1,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, R9
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_div
+done_div:
+    RET ,
+
+
+
+// func Mul32(out []float32, a []float32, b []float32)
+TEXT ·Mul32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_mul
+loopback_mul:
+    MOVUPS  (R11),X0
+    MOVUPS  (R9),X1
+    MULPS   X1,X0
+    MOVUPS  16(R11),X2
+    MOVUPS  16(R9),X3
+    MULPS   X3,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_mul
+remain_mul:
+    CMPQ    R10,$0
+    JEQ     done_mul
+onemore_mul:
+    MOVSS   (R11),X0
+    MOVSS   (R9),X1
+    MULSS   X1,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, R9
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_mul
+done_mul:
+    RET ,
+
+
+// func Add32(out []float32, a []float32, b []float32)
+TEXT ·Add32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_add
+loopback_add:
+    MOVUPS  (R11),X0
+    MOVUPS  (R9),X1
+    ADDPS   X1,X0
+    MOVUPS  16(R11),X2
+    MOVUPS  16(R9),X3
+    ADDPS   X3,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_add
+remain_add:
+    CMPQ    R10,$0
+    JEQ     done_add
+onemore_add:
+    MOVSS   (R11),X0
+    MOVSS   (R9),X1
+    ADDSS   X1,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, R9
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_add
+done_add:
+    RET ,
+
+// func Sub32(out []float32, a []float32, b []float32)
+TEXT ·Sub32(SB), 7, $0
+    MOVQ    out+0(FP),SI        // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_sub
+loopback_sub:
+    MOVUPS  (R11),X0
+    MOVUPS  (R9),X1
+    SUBPS   X1,X0
+    MOVUPS  16(R11),X2
+    MOVUPS  16(R9),X3
+    SUBPS   X3,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_sub
+remain_sub:
+    CMPQ    R10,$0
+    JEQ     done_sub
+onemore_sub:
+    MOVSS   (R11),X0
+    MOVSS   (R9),X1
+    SUBSS   X1,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, R9
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_sub
+done_sub:
+    RET ,
+
+// func Min32(out []float32, a []float32, b []float32)
+TEXT ·Min32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_min
+loopback_min:
+    MOVUPS  (R11),X0
+    MOVUPS  (R9),X1
+    MINPS   X1,X0
+    MOVUPS  16(R11),X2
+    MOVUPS  16(R9),X3
+    MINPS   X3,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_min
+remain_min:
+    CMPQ    R10,$0
+    JEQ     done_min
+onemore_min:
+    MOVSS   (R11),X0
+    MOVSS   (R9),X1
+    MINSS   X1,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, R9
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_min
+done_min:
+    RET ,
+
+// func Max32(out []float32, a []float32, b []float32)
+TEXT ·Max32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_max
+loopback_max:
+    MOVUPS  (R11),X0
+    MOVUPS  (R9),X1
+    MAXPS   X1,X0
+    MOVUPS  16(R11),X2
+    MOVUPS  16(R9),X3
+    MAXPS   X3,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_max
+remain_max:
+    CMPQ    R10,$0
+    JEQ     done_max
+onemore_max:
+    MOVSS   (R11),X0
+    MOVSS   (R9),X1
+    MAXSS   X1,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, R9
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_max
+done_max:
+    RET ,
+
+
+// func ChangeSign32(out []float64, a []float64, b []float64)
+TEXT ·ChangeSign32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    b+48(FP),R9         // R9: &b
+    MOVQ    DX, R10             // R10: len32(out)
+    MOVQ    $(1<<63), BX
+    MOVQ    BX, X4             // X4: Sign
+    SHUFPS  $0, X4, X4
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_csign
+loopback_csign:
+    MOVAPS  X4, X5
+    MOVAPS  X4, X6
+    MOVUPS  (R11),X0
+    MOVUPS  (R9),X1
+    MOVUPS  16(R11),X2
+    MOVUPS  16(R9),X3
+    ANDNPS  X0, X5
+    ANDPS   X4, X1
+    ORPS    X5, X1
+
+    ANDNPS  X2, X6
+    ANDPS   X4, X3
+    ORPS    X6, X3
+    MOVUPS  X1,(SI)
+    MOVUPS  X3,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, R9
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_csign
+remain_csign:
+    CMPQ    R10,$0
+    JEQ     done_csign
+onemore_csign:
+    MOVSS   X4, X5
+    MOVSS   (R11),X0
+    MOVSS   (R9),X1
+    ANDNPS  X0, X5
+    ANDPS   X4, X1
+    ORPS    X5, X1
+    MOVSS   X1,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, R9
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_csign
+done_csign:
+    RET ,
+
+// func ConstDiv32(out []float32, a []float32, c float32)
+TEXT ·ConstDiv32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVSS   c+48(FP),X4         // X4: c
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_cdiv
+    SHUFPS  $0, X4, X4
+loopback_cdiv:
+    MOVAPS  X4, X1
+    MOVAPS  X4, X3
+    MOVUPS  (R11),X0
+    DIVPS   X0,X1
+    MOVUPS  16(R11),X2
+    DIVPS   X2,X3
+    MOVUPS  X1,(SI)
+    MOVUPS  X3,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_cdiv
+remain_cdiv:
+    CMPQ    R10,$0
+    JEQ     done_cdiv
+onemore_cdiv:
+    MOVAPS  X4, X1
+    MOVSS   (R11),X0
+    DIVSS   X0,X1
+    MOVSS   X1,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_cdiv
+done_cdiv:
+    RET ,
+
+
+// func ConstMul32(out []float32, a []float32, c float32)
+TEXT ·ConstMul32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVSS   c+48(FP),X4         // X4: c
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_cmul
+    SHUFPS  $0, X4, X4
+loopback_cmul:
+    MOVUPS  (R11),X0
+    MULPS   X4,X0
+    MOVUPS  16(R11),X2
+    MULPS   X4,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_cmul
+remain_cmul:
+    CMPQ    R10,$0
+    JEQ     done_cmul
+onemore_cmul:
+    MOVSS   (R11),X0
+    MULSS   X4,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_cmul
+done_cmul:
+    RET ,
+
+
+// func ConstAdd32(out []float32, a []float32, c float32)
+TEXT ·ConstAdd32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVSS   c+48(FP),X4         // X4: c
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_cadd
+    SHUFPS  $0, X4, X4
+loopback_cadd:
+    MOVUPS  (R11),X0
+    ADDPS   X4,X0
+    MOVUPS  16(R11),X2
+    ADDPS   X4,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_cadd
+remain_cadd:
+    CMPQ    R10,$0
+    JEQ     done_cadd
+onemore_cadd:
+    MOVSS   (R11),X0
+    ADDSS   X4,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_cadd
+done_cadd:
+    RET ,
+
+
+// func AddScaled32(y []float32, x []float32, a float32)
+TEXT ·AddScaled32(SB), 7, $0
+    MOVQ    y(FP),SI            // SI: &y
+    MOVQ    y_len+8(FP),DX      // DX: len(y)
+    MOVQ    x+24(FP),R11        // R11: &x
+    MOVSS   a+48(FP),X4         // X4: a
+    MOVQ    DX, R10             // R10: len(y)
+    SHRQ    $3, DX              // DX: len(y) / 8
+    ANDQ    $7, R10             // R10: len(y) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_madd
+    SHUFPS  $0, X4, X4
+loopback_madd:
+    MOVUPS  (R11),X0
+    MOVUPS  (SI), X5
+    MULPS   X4, X0
+    ADDPS   X5, X0
+    MOVUPS  16(R11),X2
+    MOVUPS  16(SI), X6
+    MULPS   X4, X2
+    ADDPS   X6, X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_madd
+remain_madd:
+    CMPQ    R10,$0
+    JEQ     done_madd
+onemore_madd:
+    MOVSS   (R11),X0
+    MOVSS   (SI),X1
+    MULSS   X4,X0
+    ADDSS   X1,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_madd
+done_madd:
+    RET ,
+
+// func Sqrt32(out []float32, a []float32)
+TEXT ·Sqrt32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_sqrt
+loopback_sqrt:
+    MOVUPS  (R11),X0
+    SQRTPS  X0,X0
+    MOVUPS  16(R11),X2
+    SQRTPS  X2,X2
+    MOVUPS  X0,(SI)
+    MOVUPS  X2,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_sqrt
+remain_sqrt:
+    CMPQ    R10,$0
+    JEQ     done_sqrt
+onemore_sqrt:
+    MOVSS   (R11),X0
+    SQRTSS  X0,X0
+    MOVSS   X0,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_sqrt
+done_sqrt:
+    RET ,
+
+// func Abs32(out []float32, a []float32)
+TEXT ·Abs32(SB), 7, $0
+    MOVQ    out(FP),SI          // SI: &out
+    MOVQ    out_len+8(FP),DX    // DX: len32(out)
+    MOVQ    a+24(FP),R11        // R11: &a
+    MOVQ    $(1<<31), BX
+    MOVQ    BX, X5             // X1: Sign
+    SHUFPS  $0, X5, X5
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: len32(out) / 8
+    ANDQ    $7, R10             // R10: len32(out) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_abs
+loopback_abs:
+    MOVAPS  X5, X3
+    MOVAPS  X5, X4
+    MOVUPS  (R11),X0
+    ANDNPS  X0, X3
+    MOVUPS  16(R11),X1
+    ANDNPS  X1, X4
+    MOVUPS  X3,(SI)
+    MOVUPS  X4,16(SI)
+    ADDQ    $32, R11
+    ADDQ    $32, SI
+    SUBQ    $1,DX
+    JNZ     loopback_abs
+remain_abs:
+    CMPQ    R10,$0
+    JEQ     done_abs
+onemore_abs:
+    MOVAPS  X5, X1
+    MOVSS   (R11),X0
+    ANDNPS  X0, X1
+    MOVSS   X1,(SI)
+    ADDQ    $4, R11
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     onemore_abs
+done_abs:
+    RET ,
+
+// func MinElement32(a []float32) float32
+TEXT ·MinElement32(SB), 7, $0
+    MOVQ    a(FP),SI          // SI: &a
+    MOVQ    a_len+8(FP),DX    // DX: len(a)
+    MOVSS   (SI), X0          // Initial value
+    ADDQ    $4, SI
+    SUBQ    $1, DX
+
+    SHUFPS  $0, X0, X0
+    MOVQ    DX, R10             // R10: len32(out) -1
+    SHRQ    $3, DX              // DX: (len32(out) - 1) / 8
+    ANDQ    $7, R10             // R10: (len32(out) -1 ) % 8
+    MOVAPS  X0, X1
+    CMPQ    DX ,$0
+    JEQ     remain_min_e
+next_min_e:
+    MOVUPS  (SI), X2
+    MOVUPS  16(SI), X3
+    MINPS   X2, X0
+    MINPS   X3, X1
+    ADDQ    $32, SI
+    SUBQ    $1, DX
+    JNZ next_min_e
+    CMPQ    R10, $0
+    JZ      done_min_e
+remain_min_e:
+    MOVSS   (SI), X2
+    MINSS   X2, X0
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     remain_min_e
+done_min_e:
+    MINPS    X1, X0
+    MOVAPS   X0, X1
+    MOVAPS   X0, X2
+    MOVAPS   X0, X3
+    SHUFPS   $1, X1, X1        // Put Element 1 into lower X1
+    SHUFPS   $2, X2, X2        // Put Element 2 into lower X2
+    SHUFPS   $3, X3, X3        // Put Element 3 into lower X3
+
+    MINSS    X1, X0
+    MINSS    X3, X2
+    MINSS    X2, X0
+    MOVSS    X0, ret+24(FP)
+    RET ,
+
+
+// func MaxElement32(a []float32) float32
+TEXT ·MaxElement32(SB), 7, $0
+    MOVQ    a(FP),SI          // SI: &a
+    MOVQ    a_len+8(FP),DX    // DX: len(a)
+    MOVSS   (SI), X0          // Initial value
+    ADDQ    $4, SI
+    SUBQ    $1, DX
+
+    SHUFPS  $0, X0, X0
+    MOVQ    DX, R10             // R10: len32(out) -1
+    SHRQ    $3, DX              // DX: (len32(out) - 1) / 8
+    ANDQ    $7, R10             // R10: (len32(out) -1 ) % 8
+    MOVAPS  X0, X1
+    CMPQ    DX ,$0
+    JEQ     remain_max_e
+next_max_e:
+    MOVUPS  (SI), X2
+    MOVUPS  16(SI), X3
+    MAXPS   X2, X0
+    MAXPS   X3, X1
+    ADDQ    $32, SI
+    SUBQ    $1, DX
+    JNZ next_max_e
+    CMPQ    R10, $0
+    JZ      done_max_e
+remain_max_e:
+    MOVSS   (SI), X2
+    MAXSS   X2, X0
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     remain_max_e
+done_max_e:
+    MAXPS    X1, X0
+    MOVAPS   X0, X1
+    MOVAPS   X0, X2
+    MOVAPS   X0, X3
+    SHUFPS   $1, X1, X1        // Put Element 1 into lower X1
+    SHUFPS   $2, X2, X2        // Put Element 2 into lower X2
+    SHUFPS   $3, X3, X3        // Put Element 3 into lower X3
+
+    MAXSS    X1, X0
+    MAXSS    X3, X2
+    MAXSS    X2, X0
+    MOVSS    X0, ret+24(FP)
+    RET ,
+
+
+
+// func Sum32(a []float32) float32
+TEXT ·Sum32(SB), 7, $0
+    MOVQ    a(FP),SI          // SI: &a
+    MOVQ    a_len+8(FP),DX    // DX: len(a)
+    XORPS   X0, X0            // Sum 1
+    XORPS   X1, X1            // Sum 2
+
+    MOVQ    DX, R10             // R10: len32(out)
+    SHRQ    $3, DX              // DX: (len32(out)) / 8
+    ANDQ    $7, R10             // R10: (len32(out)) % 8
+    CMPQ    DX ,$0
+    JEQ     remain_sum
+next_sum:
+    MOVUPS  (SI), X2
+    MOVUPS  16(SI), X3
+    ADDPS   X2, X0
+    ADDPS   X3, X1
+    ADDQ    $32, SI
+    SUBQ    $1, DX
+    JNZ     next_sum
+    CMPQ    R10, $0
+    JZ      done_sum
+remain_sum:
+    MOVSS   (SI), X2
+    ADDSS   X2, X0
+    ADDQ    $4, SI
+    SUBQ    $1, R10
+    JNZ     remain_sum
+done_sum:
+    ADDPS   X1, X0
+    MOVAPS  X0, X1
+    MOVAPS  X0, X2
+    MOVAPS  X0, X3
+    SHUFPS  $1, X1, X1        // Put Element 1 into lower X1
+    SHUFPS  $2, X2, X2        // Put Element 2 into lower X2
+    SHUFPS  $3, X3, X3        // Put Element 3 into lower X3
+
+    ADDSS   X1, X0
+    ADDSS   X3, X2
+    ADDSS   X2, X0
+
+    MOVSS   X0, ret+24(FP)
+    RET ,


### PR DESCRIPTION
This adds assembler functions for common single and double precision operations. The assembler functions usually are more than twice as fast as pure Go operations. The speedups listed in Xslice.go is on a slice with 10000 elements.

If you think we should move on with this, I will add tests and license, and whatever you think also may be missing.
