### PR TITLE
Generalized DaxpyInc

### DIFF
--- a/asm/daxpy.go
+++ b/asm/daxpy.go
@@ -13,10 +13,11 @@ func DaxpyUnitary(alpha float64, x, y, z []float64) {
 	}
 }
 
-func DaxpyInc(alpha float64, x, y []float64, n, incX, incY, ix, iy uintptr) {
+func DaxpyInc(alpha float64, x, y, z []float64, n, incX, incY, incZ, ix, iy, iz uintptr) {
 	for i := 0; i < int(n); i++ {
-		y[iy] += alpha * x[ix]
+		z[iz] = alpha*x[ix] + y[iy]
 		ix += incX
 		iy += incY
+		iz += incZ
 	}
 }

--- a/asm/daxpy_amd64.go
+++ b/asm/daxpy_amd64.go
@@ -6,7 +6,6 @@
 
 package asm
 
-// The extra z parameter is needed because of floats.AddScaledTo
 func DaxpyUnitary(alpha float64, x, y, z []float64)
 
-func DaxpyInc(alpha float64, x, y []float64, n, incX, incY, ix, iy uintptr)
+func DaxpyInc(alpha float64, x, y, z []float64, n, incX, incY, incZ, ix, iy, iz uintptr)

--- a/asm/daxpy_test.go
+++ b/asm/daxpy_test.go
@@ -4,9 +4,13 @@
 
 package asm
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestDaxpyUnitary(t *testing.T) {
+	// Test z = alpha * x + y.
 	for i, test := range []struct {
 		alpha float64
 		xData []float64
@@ -14,17 +18,12 @@ func TestDaxpyUnitary(t *testing.T) {
 
 		want []float64
 	}{
+		// One element
 		{
 			alpha: 0,
 			xData: []float64{2},
 			yData: []float64{-3},
 			want:  []float64{-3},
-		},
-		{
-			alpha: 1,
-			xData: []float64{2},
-			yData: []float64{-3},
-			want:  []float64{-1},
 		},
 		{
 			alpha: 3,
@@ -38,17 +37,12 @@ func TestDaxpyUnitary(t *testing.T) {
 			yData: []float64{-3},
 			want:  []float64{-9},
 		},
+		// Odd number of elements
 		{
 			alpha: 0,
 			xData: []float64{0, 0, 1, 1, 2, -3, -4},
 			yData: []float64{0, 1, 0, 3, -4, 5, -6},
 			want:  []float64{0, 1, 0, 3, -4, 5, -6},
-		},
-		{
-			alpha: 1,
-			xData: []float64{0, 0, 1, 1, 2, -3, -4},
-			yData: []float64{0, 1, 0, 3, -4, 5, -6},
-			want:  []float64{0, 1, 1, 4, -2, 2, -10},
 		},
 		{
 			alpha: 3,
@@ -62,6 +56,13 @@ func TestDaxpyUnitary(t *testing.T) {
 			yData: []float64{0, 1, 0, 3, -4, 5, -6},
 			want:  []float64{0, 1, -3, 0, -10, 14, 6},
 		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4, 5},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6, 7},
+			want:  []float64{0, 1, -5, -2, -14, 20, 14, -18},
+		},
 	} {
 		x, xFront, xBack := newGuardedVector(test.xData, 1)
 		y, yFront, yBack := newGuardedVector(test.yData, 1)
@@ -69,27 +70,605 @@ func TestDaxpyUnitary(t *testing.T) {
 
 		DaxpyUnitary(test.alpha, x, y, z)
 
-		if !allNaN(xFront) || !allNaN(xBack) {
-			t.Errorf("test %v: out-of-bounds write to x argument\nfront guard: %v\nback guard: %v\n",
-				i, xFront, xBack)
-		}
-		if !allNaN(yFront) || !allNaN(yBack) {
-			t.Errorf("test %v: out-of-bounds write to y argument\nfront guard: %v\nback guard: %v\n",
-				i, yFront, yBack)
-		}
-		if !allNaN(zFront) || !allNaN(zBack) {
-			t.Errorf("test %v: out-of-bounds write to z argument\nfront guard: %v\nback guard: %v\n",
-				i, zFront, zBack)
+		prefix := fmt.Sprintf("test %v (z=a*x+y)", i)
+
+		if err := checkGuardsXYZ(xFront, xBack, yFront, yBack, zFront, zBack); err != nil {
+			t.Errorf("%v: %v", prefix, err)
 		}
 		if !equalStrided(test.xData, x, 1) {
-			t.Errorf("test %v: modified x argument", i)
+			t.Errorf("%v: modified read-only x argument", prefix)
 		}
 		if !equalStrided(test.yData, y, 1) {
-			t.Errorf("test %v: modified y argument", i)
+			t.Errorf("%v: modified read-only y argument", prefix)
 		}
 
 		if !equalStrided(test.want, z, 1) {
-			t.Errorf("test %v: unexpected result:\nwant: %v\ngot: %v", i, test.want, z)
+			t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, z)
+		}
+	}
+
+	// Test y = alpha * x + y.
+	for i, test := range []struct {
+		alpha float64
+		xData []float64
+		yData []float64
+
+		want []float64
+	}{
+		// One element
+		{
+			alpha: 0,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-3},
+		},
+		{
+			alpha: 3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{3},
+		},
+		{
+			alpha: -3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-9},
+		},
+		// Odd number of elements
+		{
+			alpha: 0,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 0, 3, -4, 5, -6},
+		},
+		{
+			alpha: 3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 3, 6, 2, -4, -18},
+		},
+		{
+			alpha: -3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, -3, 0, -10, 14, 6},
+		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4, 5},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6, 7},
+			want:  []float64{0, 1, -5, -2, -14, 20, 14, -18},
+		},
+	} {
+		x, xFront, xBack := newGuardedVector(test.xData, 1)
+		y, yFront, yBack := newGuardedVector(test.yData, 1)
+
+		DaxpyUnitary(test.alpha, x, y, y)
+
+		prefix := fmt.Sprintf("test %v (y=a*x+y)", i)
+
+		if err := checkGuardsXY(xFront, xBack, yFront, yBack); err != nil {
+			t.Errorf("%v: %v", prefix, err)
+		}
+		if !equalStrided(test.xData, x, 1) {
+			t.Errorf("%v: modified read-only x argument", prefix)
+		}
+
+		if !equalStrided(test.want, y, 1) {
+			t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, y)
+		}
+	}
+
+	// Test x = alpha * x + y.
+	for i, test := range []struct {
+		alpha float64
+		xData []float64
+		yData []float64
+
+		want []float64
+	}{
+		// One element
+		{
+			alpha: 0,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-3},
+		},
+		{
+			alpha: 3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{3},
+		},
+		{
+			alpha: -3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-9},
+		},
+		// Odd number of elements
+		{
+			alpha: 0,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 0, 3, -4, 5, -6},
+		},
+		{
+			alpha: 3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 3, 6, 2, -4, -18},
+		},
+		{
+			alpha: -3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, -3, 0, -10, 14, 6},
+		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4, 5},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6, 7},
+			want:  []float64{0, 1, -5, -2, -14, 20, 14, -18},
+		},
+	} {
+		x, xFront, xBack := newGuardedVector(test.xData, 1)
+		y, yFront, yBack := newGuardedVector(test.yData, 1)
+
+		DaxpyUnitary(test.alpha, x, y, x)
+
+		prefix := fmt.Sprintf("test %v (x=a*x+y)", i)
+
+		if err := checkGuardsXY(xFront, xBack, yFront, yBack); err != nil {
+			t.Errorf("%v: %v", prefix, err)
+		}
+		if !equalStrided(test.yData, y, 1) {
+			t.Errorf("%v: modified read-only y argument", prefix)
+		}
+
+		if !equalStrided(test.want, x, 1) {
+			t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, x)
+		}
+	}
+
+	// Test x = alpha * x + x.
+	for i, test := range []struct {
+		alpha float64
+		xData []float64
+
+		want []float64
+	}{
+		// One element
+		{
+			alpha: 0,
+			xData: []float64{2},
+			want:  []float64{2},
+		},
+		{
+			alpha: 3,
+			xData: []float64{2},
+			want:  []float64{8},
+		},
+		{
+			alpha: -3,
+			xData: []float64{2},
+			want:  []float64{-4},
+		},
+		// Odd number of elements
+		{
+			alpha: 0,
+			xData: []float64{0, 1, 2, -3, -4},
+			want:  []float64{0, 1, 2, -3, -4},
+		},
+		{
+			alpha: 3,
+			xData: []float64{0, 1, 2, -3, -4},
+			want:  []float64{0, 4, 8, -12, -16},
+		},
+		{
+			alpha: -3,
+			xData: []float64{0, 1, 2, -3, -4},
+			want:  []float64{0, -2, -4, 6, 8},
+		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 1, 2, -3, -4, 5},
+			want:  []float64{0, -4, -8, 12, 16, -20},
+		},
+	} {
+		x, xFront, xBack := newGuardedVector(test.xData, 1)
+
+		DaxpyUnitary(test.alpha, x, x, x)
+
+		prefix := fmt.Sprintf("test %v (x=a*x+x)", i)
+
+		if !allNaN(xFront) || !allNaN(xBack) {
+			t.Errorf("%v: out-of-bounds write to x argument\nfront guard: %v\nback guard: %v", prefix, xFront, xBack)
+		}
+
+		if !equalStrided(test.want, x, 1) {
+			t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, x)
+		}
+	}
+}
+
+func TestDaxpyInc(t *testing.T) {
+	// Test z = alpha * x + y.
+	for i, test := range []struct {
+		alpha float64
+		xData []float64
+		yData []float64
+
+		want []float64
+	}{
+		// One element
+		{
+			alpha: 0,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-3},
+		},
+		{
+			alpha: 3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{3},
+		},
+		{
+			alpha: -3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-9},
+		},
+		// Odd number of elements
+		{
+			alpha: 0,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 0, 3, -4, 5, -6},
+		},
+		{
+			alpha: 3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 3, 6, 2, -4, -18},
+		},
+		{
+			alpha: -3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, -3, 0, -10, 14, 6},
+		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4, 5},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6, 7},
+			want:  []float64{0, 1, -5, -2, -14, 20, 14, -18},
+		},
+	} {
+		for _, incX := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+			for _, incY := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+				for _, incZ := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+					switch {
+					case incX > 0 && incY > 0 && incZ > 0:
+					case incX < 0 && incY < 0 && incZ < 0:
+					default:
+						continue
+					}
+					// All increments have the same sign.
+
+					x, xFront, xBack := newGuardedVector(test.xData, incX)
+					y, yFront, yBack := newGuardedVector(test.yData, incY)
+					z, zFront, zBack := newGuardedVector(test.xData, incZ)
+					n := len(test.xData)
+
+					var ix, iy, iz int
+					if incX < 0 {
+						ix = (-n + 1) * incX
+					}
+					if incY < 0 {
+						iy = (-n + 1) * incY
+					}
+					if incZ < 0 {
+						iz = (-n + 1) * incZ
+					}
+					DaxpyInc(test.alpha, x, y, z, uintptr(n),
+						uintptr(incX), uintptr(incY), uintptr(incZ),
+						uintptr(ix), uintptr(iy), uintptr(iz))
+
+					prefix := fmt.Sprintf("test %v (z=a*x+y), incX = %v, incY = %v, incZ = %v", i, incX, incY, incZ)
+
+					if err := checkGuardsXYZ(xFront, xBack, yFront, yBack, zFront, zBack); err != nil {
+						t.Errorf("%v: %v", prefix, err)
+					}
+					if nonStridedWrite(x, incX) || !equalStrided(test.xData, x, incX) {
+						t.Errorf("%v: modified read-only x argument", prefix)
+					}
+					if nonStridedWrite(y, incY) || !equalStrided(test.yData, y, incY) {
+						t.Errorf("%v: modified read-only y argument", prefix)
+					}
+					if nonStridedWrite(z, incZ) {
+						t.Errorf("%v: modified z argument at non-stride position", prefix)
+					}
+
+					if !equalStrided(test.want, z, incZ) {
+						t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, z)
+					}
+				}
+			}
+		}
+	}
+
+	// Test y = alpha * x + y.
+	for i, test := range []struct {
+		alpha float64
+		xData []float64
+		yData []float64
+
+		want []float64
+	}{
+		// One element
+		{
+			alpha: 0,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-3},
+		},
+		{
+			alpha: 3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{3},
+		},
+		{
+			alpha: -3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-9},
+		},
+		// Odd number of elements
+		{
+			alpha: 0,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 0, 3, -4, 5, -6},
+		},
+		{
+			alpha: 3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 3, 6, 2, -4, -18},
+		},
+		{
+			alpha: -3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, -3, 0, -10, 14, 6},
+		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4, 5},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6, 7},
+			want:  []float64{0, 1, -5, -2, -14, 20, 14, -18},
+		},
+	} {
+		for _, incX := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+			for _, incY := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+				switch {
+				case incX > 0 && incY > 0:
+				case incX < 0 && incY < 0:
+				default:
+					continue
+				}
+				// All increments have the same sign.
+
+				x, xFront, xBack := newGuardedVector(test.xData, incX)
+				y, yFront, yBack := newGuardedVector(test.yData, incY)
+				n := len(test.xData)
+
+				var ix, iy int
+				if incX < 0 {
+					ix = (-n + 1) * incX
+				}
+				if incY < 0 {
+					iy = (-n + 1) * incY
+				}
+				DaxpyInc(test.alpha, x, y, y, uintptr(n),
+					uintptr(incX), uintptr(incY), uintptr(incY),
+					uintptr(ix), uintptr(iy), uintptr(iy))
+
+				prefix := fmt.Sprintf("test %v (y=a*x+y), incX = %v, incY = %v", i, incX, incY)
+
+				if err := checkGuardsXY(xFront, xBack, yFront, yBack); err != nil {
+					t.Errorf("%v: %v", prefix, err)
+				}
+				if nonStridedWrite(x, incX) || !equalStrided(test.xData, x, incX) {
+					t.Errorf("%v: modified read-only x argument", prefix)
+				}
+				if nonStridedWrite(y, incY) {
+					t.Errorf("%v: modified y argument at non-stride position", prefix)
+				}
+
+				if !equalStrided(test.want, y, incY) {
+					t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, y)
+				}
+			}
+		}
+	}
+
+	// Test x = alpha * x + y.
+	for i, test := range []struct {
+		alpha float64
+		xData []float64
+		yData []float64
+
+		want []float64
+	}{
+		// One element
+		{
+			alpha: 0,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-3},
+		},
+		{
+			alpha: 3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{3},
+		},
+		{
+			alpha: -3,
+			xData: []float64{2},
+			yData: []float64{-3},
+			want:  []float64{-9},
+		},
+		// Odd number of elements
+		{
+			alpha: 0,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 0, 3, -4, 5, -6},
+		},
+		{
+			alpha: 3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, 3, 6, 2, -4, -18},
+		},
+		{
+			alpha: -3,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6},
+			want:  []float64{0, 1, -3, 0, -10, 14, 6},
+		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 0, 1, 1, 2, -3, -4, 5},
+			yData: []float64{0, 1, 0, 3, -4, 5, -6, 7},
+			want:  []float64{0, 1, -5, -2, -14, 20, 14, -18},
+		},
+	} {
+		for _, incX := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+			for _, incY := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+				switch {
+				case incX > 0 && incY > 0:
+				case incX < 0 && incY < 0:
+				default:
+					continue
+				}
+				// All increments have the same sign.
+
+				x, xFront, xBack := newGuardedVector(test.xData, incX)
+				y, yFront, yBack := newGuardedVector(test.yData, incY)
+				n := len(test.xData)
+
+				var ix, iy int
+				if incX < 0 {
+					ix = (-n + 1) * incX
+				}
+				if incY < 0 {
+					iy = (-n + 1) * incY
+				}
+				DaxpyInc(test.alpha, x, y, x, uintptr(n),
+					uintptr(incX), uintptr(incY), uintptr(incX),
+					uintptr(ix), uintptr(iy), uintptr(ix))
+
+				prefix := fmt.Sprintf("test %v (x=a*x+y), incX = %v, incY = %v", i, incX, incY)
+
+				if err := checkGuardsXY(xFront, xBack, yFront, yBack); err != nil {
+					t.Errorf("%v: %v", prefix, err)
+				}
+				if nonStridedWrite(y, incY) || !equalStrided(test.yData, y, incY) {
+					t.Errorf("%v: modified read-only y argument", prefix)
+				}
+				if nonStridedWrite(x, incX) {
+					t.Errorf("%v: modified x argument at non-stride position", prefix)
+				}
+
+				if !equalStrided(test.want, x, incX) {
+					t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, x)
+				}
+			}
+		}
+	}
+
+	// Test x = alpha * x + x.
+	for i, test := range []struct {
+		alpha float64
+		xData []float64
+
+		want []float64
+	}{
+		// One element
+		{
+			alpha: 0,
+			xData: []float64{2},
+			want:  []float64{2},
+		},
+		{
+			alpha: 3,
+			xData: []float64{2},
+			want:  []float64{8},
+		},
+		{
+			alpha: -3,
+			xData: []float64{2},
+			want:  []float64{-4},
+		},
+		// Odd number of elements
+		{
+			alpha: 0,
+			xData: []float64{0, 1, 2, -3, -4},
+			want:  []float64{0, 1, 2, -3, -4},
+		},
+		{
+			alpha: 3,
+			xData: []float64{0, 1, 2, -3, -4},
+			want:  []float64{0, 4, 8, -12, -16},
+		},
+		{
+			alpha: -3,
+			xData: []float64{0, 1, 2, -3, -4},
+			want:  []float64{0, -2, -4, 6, 8},
+		},
+		// Even number of elements
+		{
+			alpha: -5,
+			xData: []float64{0, 1, 2, -3, -4, 5},
+			want:  []float64{0, -4, -8, 12, 16, -20},
+		},
+	} {
+		for _, incX := range []int{-7, -4, -3, -2, -1, 1, 2, 3, 4, 7} {
+			x, xFront, xBack := newGuardedVector(test.xData, incX)
+			n := len(test.xData)
+
+			var ix int
+			if incX < 0 {
+				ix = (-n + 1) * incX
+			}
+			DaxpyInc(test.alpha, x, x, x, uintptr(n),
+				uintptr(incX), uintptr(incX), uintptr(incX),
+				uintptr(ix), uintptr(ix), uintptr(ix))
+
+			prefix := fmt.Sprintf("test %v (x=a*x+x), incX = %v", i, incX)
+
+			if !allNaN(xFront) || !allNaN(xBack) {
+				t.Errorf("%v: out-of-bounds write to x argument\nfront guard: %v\nback guard: %v", i, xFront, xBack)
+			}
+			if nonStridedWrite(x, incX) {
+				t.Errorf("%v: modified x argument at non-stride position", prefix)
+			}
+
+			if !equalStrided(test.want, x, incX) {
+				t.Errorf("%v: unexpected result:\nwant: %v\ngot: %v", prefix, test.want, x)
+			}
 		}
 	}
 }

--- a/asm/ddot_test.go
+++ b/asm/ddot_test.go
@@ -5,6 +5,7 @@
 package asm
 
 import (
+	"fmt"
 	"math"
 	"testing"
 )
@@ -157,20 +158,56 @@ func allNaN(x []float64) bool {
 }
 
 // equalStrided returns true if the strided vector x contains elements of the
-// dense vector ref at indices i*inc and NaN values elsewhere, false otherwise.
+// dense vector ref at indices i*inc, false otherwise.
 func equalStrided(ref, x []float64, inc int) bool {
 	if inc < 0 {
 		inc = -inc
 	}
 	for i, v := range x {
-		if i%inc == 0 {
-			if ref[i/inc] != v {
-				return false
-
-			}
-		} else if !math.IsNaN(v) {
+		if i%inc == 0 && ref[i/inc] != v {
 			return false
 		}
 	}
 	return true
+}
+
+// nonStridedWrite returns false if all elements of x at non-stride indices are
+// equal to NaN, true otherwise.
+func nonStridedWrite(x []float64, inc int) bool {
+	if inc < 0 {
+		inc = -inc
+	}
+	for i, v := range x {
+		if i%inc != 0 && !math.IsNaN(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkGuardsXY checks whether all given slices contain only NaN values.
+func checkGuardsXY(xFront, xBack, yFront, yBack []float64) error {
+	msg := "out-of-bounds write to %v argument\nfront guard: %v\nback guard: %v"
+	if !allNaN(xFront) || !allNaN(xBack) {
+		return fmt.Errorf(msg, "x", xFront, xBack)
+	}
+	if !allNaN(yFront) || !allNaN(yBack) {
+		return fmt.Errorf(msg, "y", yFront, yBack)
+	}
+	return nil
+}
+
+// checkGuardsXYZ checks whether all given slices contain only NaN values.
+func checkGuardsXYZ(xFront, xBack, yFront, yBack, zFront, zBack []float64) error {
+	msg := "out-of-bounds write to %v argument\nfront guard: %v\nback guard: %v"
+	if !allNaN(xFront) || !allNaN(xBack) {
+		return fmt.Errorf(msg, "x", xFront, xBack)
+	}
+	if !allNaN(yFront) || !allNaN(yBack) {
+		return fmt.Errorf(msg, "y", yFront, yBack)
+	}
+	if !allNaN(zFront) || !allNaN(zBack) {
+		return fmt.Errorf(msg, "z", zFront, zBack)
+	}
+	return nil
 }


### PR DESCRIPTION
This generalization of `asm.DaxpyInc` leads to a slightly reduced performance in BLAS, as expected. On the other hand it provides a nice speedup for `mat64.Vector`. One option would be to have a two-slice version for BLAS and a three-slice version for mat64 for the price of having three assembler versions of Daxpy instead of two. Opinions, @kortschak @btracey @fhs ?

`benchstat` gives these number on my Intel(R) Xeon(R) CPU E5-1650 v3 @ 3.50GHz.

```
DaxpySmallBothUnitary-6   12.8ns ± 1%  13.3ns ± 1%   +3.91%  (p=0.029 n=4+4)
DaxpySmallIncUni-6        18.8ns ± 0%  20.7ns ± 0%  +10.25%  (p=0.029 n=4+4)
DaxpySmallUniInc-6        18.7ns ± 0%  20.9ns ± 0%  +11.63%  (p=0.029 n=4+4)
DaxpySmallBothInc-6       18.5ns ± 0%  20.6ns ± 0%  +11.35%  (p=0.029 n=4+4)
DaxpyMediumBothUnitary-6   272ns ± 0%   314ns ± 1%  +15.46%  (p=0.029 n=4+4)
DaxpyMediumIncUni-6       1.05µs ± 1%  1.04µs ± 0%   -1.19%  (p=0.029 n=4+4)
DaxpyMediumUniInc-6       1.02µs ± 0%  1.03µs ± 0%     ~     (p=0.114 n=4+4)
DaxpyMediumBothInc-6      1.09µs ± 0%  1.09µs ± 1%     ~     (p=1.000 n=4+4)
DaxpyLargeBothUnitary-6   55.9µs ± 1%  56.2µs ± 0%     ~     (p=0.343 n=4+4)
DaxpyLargeIncUni-6         148µs ± 1%   149µs ± 1%     ~     (p=0.486 n=4+4)
DaxpyLargeUniInc-6         146µs ± 3%   151µs ± 0%     ~     (p=0.343 n=4+4)
DaxpyLargeBothInc-6        200µs ± 0%   195µs ± 0%   -2.22%  (p=0.029 n=4+4)
DaxpyHugeBothUnitary-6    13.7ms ± 1%  13.5ms ± 0%   -1.82%  (p=0.029 n=4+4)
DaxpyHugeIncUni-6         38.6ms ± 1%  37.6ms ± 0%   -2.72%  (p=0.029 n=4+4)
DaxpyHugeUniInc-6         29.6ms ± 1%  29.1ms ± 1%     ~     (p=0.114 n=4+4)
DaxpyHugeBothInc-6        51.8ms ± 0%  50.7ms ± 0%   -1.98%  (p=0.029 n=4+4)
```

```
DgemmSmSmSm-6        1.08µs ± 0%  1.10µs ± 1%   +1.43%  (p=0.029 n=4+4)
DgemmMedMedMed-6      369µs ± 1%   381µs ± 1%   +3.05%  (p=0.029 n=4+4)
DgemmMedLgMed-6       984µs ± 1%  1152µs ± 0%  +17.14%  (p=0.029 n=4+4)
DgemmLgLgLg-6        82.4ms ± 0%  96.0ms ± 1%  +16.54%  (p=0.029 n=4+4)
DgemmLgSmLg-6        2.03ms ± 0%  2.03ms ± 1%     ~     (p=0.343 n=4+4)
DgemmLgLgSm-6        1.21ms ± 3%  1.39ms ± 1%  +14.52%  (p=0.029 n=4+4)
DgemmHgHgSm-6         112ms ± 0%   134ms ± 1%  +19.91%  (p=0.029 n=4+4)
DgemmMedMedMedTNT-6   385µs ± 0%   396µs ± 0%   +2.84%  (p=0.029 n=4+4)
DgemmMedMedMedNTT-6   220µs ± 0%   221µs ± 0%   +0.79%  (p=0.029 n=4+4)
DgemmMedMedMedTT-6    553µs ± 0%   565µs ± 0%   +2.15%  (p=0.029 n=4+4)
```

```
AddScaledVec10Inc2-6       55.7ns ± 0%  21.9ns ± 0%  -60.68%  (p=0.029 n=4+4)
AddScaledVec100Inc2-6       240ns ± 1%   116ns ± 0%  -51.62%  (p=0.029 n=4+4)
AddScaledVec1000Inc2-6     1.93µs ± 0%  1.05µs ± 0%  -45.45%  (p=0.029 n=4+4)
AddScaledVec10000Inc2-6    20.4µs ± 0%  11.8µs ± 1%  -42.01%  (p=0.029 n=4+4)
AddScaledVec100000Inc2-6    223µs ± 0%   123µs ± 0%  -44.80%  (p=0.029 n=4+4)
AddScaledVec10Inc20-6      56.0ns ± 0%  22.5ns ± 0%  -59.80%  (p=0.029 n=4+4)
AddScaledVec100Inc20-6      239ns ± 0%   116ns ± 0%  -51.36%  (p=0.029 n=4+4)
AddScaledVec1000Inc20-6    2.86µs ± 2%  2.58µs ± 4%   -9.75%  (p=0.029 n=4+4)
AddScaledVec10000Inc20-6   44.2µs ± 0%  41.2µs ± 1%   -6.94%  (p=0.029 n=4+4)
AddScaledVec100000Inc20-6  1.76ms ± 2%  1.54ms ± 0%  -12.52%  (p=0.029 n=4+4)
```
