### PR TITLE
asm: unroll 4x DdotUnitary

### DIFF
--- a/asm/ddot_amd64.s
+++ b/asm/ddot_amd64.s
@@ -44,13 +44,13 @@
 // func DdotUnitary(x, y []float64) (sum float64)
 // This function assumes len(y) >= len(x).
 TEXT ·DdotUnitary(SB), NOSPLIT, $0
-	MOVQ x_len+8(FP), DI // n = len(x)
 	MOVQ x+0(FP), R8
+	MOVQ x_len+8(FP), DI // n = len(x)
 	MOVQ y+24(FP), R9
 
-	MOVQ  $0, SI     // i = 0
 	MOVSD $(0.0), X7 // sum = 0
 
+	MOVQ $0, SI   // i = 0
 	SUBQ $2, DI   // n -= 2
 	JL   tail_uni // if n < 0 goto tail_uni
 


### PR DESCRIPTION
PTAL, @kortschak 

```
DdotUnitaryN1       3.59ns ± 0%  4.13ns ± 0%  +15.04%  (p=0.029 n=4+4)
DdotUnitaryN2       3.69ns ± 0%  4.65ns ± 0%  +26.02%  (p=0.029 n=4+4)
DdotUnitaryN3       4.14ns ± 0%  5.20ns ± 0%  +25.48%  (p=0.029 n=4+4)
DdotUnitaryN4       4.59ns ± 0%  4.57ns ± 0%   -0.49%  (p=0.029 n=4+4)
DdotUnitaryN10      6.07ns ± 0%  6.53ns ± 0%   +7.58%  (p=0.029 n=4+4)
DdotUnitaryN100     38.2ns ± 0%  24.4ns ± 0%  -36.13%  (p=0.029 n=4+4)
DdotUnitaryN1000     424ns ± 0%   219ns ± 0%  -48.35%  (p=0.029 n=4+4)
DdotUnitaryN10000   4.31µs ± 0%  2.79µs ± 0%  -35.30%  (p=0.029 n=4+4)
DdotUnitaryN100000  45.5µs ± 1%  40.7µs ± 0%  -10.50%  (p=0.029 n=4+4)
```
