### PR TITLE
asm/f64: Alignment bug in DivTo fixed with test added.

### DIFF
--- a/asm/f64/divto_amd64.s
+++ b/asm/f64/divto_amd64.s
@@ -20,8 +20,8 @@ TEXT ·DivTo(SB), NOSPLIT, $0
 	CMPQ    CX, $0             // if CX == 0 { return }
 	JE      div_end
 	XORQ    AX, AX             // i = 0
-	MOVQ    DI, BX
-	ANDQ    $15, BX            // BX = &dst & OxF
+	MOVQ    DX, BX
+	ANDQ    $15, BX            // BX = &y & OxF
 	JZ      div_no_trim        // if BX == 0 { goto div_no_trim }
 
 	// Align on 16-bit boundary

--- a/asm/f64/stubs_test.go
+++ b/asm/f64/stubs_test.go
@@ -460,14 +460,14 @@ func TestDiv(t *testing.T) {
 			expect: []float64{0, 0, 0},
 		},
 		{
-			dst:    []float64{nan, 1, nan, 1, 0},
-			src:    []float64{1, 1, nan, 1, 1},
-			expect: []float64{nan, 1, nan, 1, 0},
+			dst:    []float64{nan, 1, nan, 1, 0, nan, 1, nan, 1, 0},
+			src:    []float64{1, 1, nan, 1, 1, 1, 1, nan, 1, 1},
+			expect: []float64{nan, 1, nan, 1, 0, nan, 1, nan, 1, 0},
 		},
 		{
-			dst:    []float64{inf, 4, nan, -inf, 9},
-			src:    []float64{inf, 4, nan, -inf, 3},
-			expect: []float64{nan, 1, nan, nan, 3},
+			dst:    []float64{inf, 4, nan, -inf, 9, inf, 4, nan, -inf, 9},
+			src:    []float64{inf, 4, nan, -inf, 3, inf, 4, nan, -inf, 3},
+			expect: []float64{nan, 1, nan, nan, 3, nan, 1, nan, nan, 3},
 		},
 	} {
 		sg_ln, dg_ln := 4+j%2, 4+j%3
@@ -524,16 +524,16 @@ func TestDivTo(t *testing.T) {
 			expect: []float64{0, 0, 0},
 		},
 		{
-			dst:    []float64{inf, inf, inf, inf, inf},
-			x:      []float64{nan, 1, nan, 1, 0},
-			y:      []float64{1, 1, nan, 1, 1},
-			expect: []float64{nan, 1, nan, 1, 0},
+			dst:    []float64{inf, inf, inf, inf, inf, inf, inf, inf, inf, inf},
+			x:      []float64{nan, 1, nan, 1, 0, nan, 1, nan, 1, 0},
+			y:      []float64{1, 1, nan, 1, 1, 1, 1, nan, 1, 1},
+			expect: []float64{nan, 1, nan, 1, 0, nan, 1, nan, 1, 0},
 		},
 		{
-			dst:    []float64{0, 0, 0, 0, 0},
-			x:      []float64{inf, 4, nan, -inf, 9},
-			y:      []float64{inf, 4, nan, -inf, 3},
-			expect: []float64{nan, 1, nan, nan, 3},
+			dst:    []float64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			x:      []float64{inf, 4, nan, -inf, 9, inf, 4, nan, -inf, 9},
+			y:      []float64{inf, 4, nan, -inf, 3, inf, 4, nan, -inf, 3},
+			expect: []float64{nan, 1, nan, nan, 3, nan, 1, nan, nan, 3},
 		},
 	} {
 		xg_ln, yg_ln := 4+j%2, 4+j%3


### PR DESCRIPTION
DIVPD using memory requires 16-byte alignment.  Alignment block was testing against `dst` slice instead of `y` slice.  