### PR TITLE
internal/README: add gddo link and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gonum Internal [![Build Status](https://travis-ci.org/gonum/internal.svg?branch=master)](https://travis-ci.org/gonum/internal) [![Coverage Status](https://coveralls.io/repos/gonum/internal/badge.svg?branch=master&service=github)](https://coveralls.io/github/gonum/internal?branch=master)
+# Gonum Internal [![Build Status](https://travis-ci.org/gonum/internal.svg?branch=master)](https://travis-ci.org/gonum/internal) [![Coverage Status](https://coveralls.io/repos/gonum/internal/badge.svg?branch=master&service=github)](https://coveralls.io/github/gonum/internal?branch=master) [![GoDoc](https://godoc.org/github.com/gonum/internal?status.svg)](https://godoc.org/github.com/gonum/internal)
 
 This is the set of internal packages for the Gonum project.
 


### PR DESCRIPTION
Please take a look.

Note that godoc servers do not show paths to internal packages, but godoc.org does.