### PR TITLE
asm/f64: Updated scal assembly to wide, pipelined loops.

### DIFF
--- a/asm/f64/asm_test.go
+++ b/asm/f64/asm_test.go
@@ -140,6 +140,7 @@ func same(a, b float64) bool {
 }
 
 var ( // Offset sets for testing alignment handling in Unitary assembly functions.
+	align1 = []int{0, 1}
 	align2 = newIncSet(0, 1)
 	align3 = newIncToSet(0, 1)
 )
@@ -187,6 +188,17 @@ func randomSlice(n, inc int) []float64 {
 	x := make([]float64, (n-1)*inc+1)
 	for i := range x {
 		x[i] = rand.Float64()
+	}
+	return x
+}
+
+func randSlice(n, inc int, r *rand.Rand) []float64 {
+	if inc < 0 {
+		inc = -inc
+	}
+	x := make([]float64, (n-1)*inc+1)
+	for i := range x {
+		x[i] = r.Float64()
 	}
 	return x
 }

--- a/asm/f64/benchScal_test.go
+++ b/asm/f64/benchScal_test.go
@@ -1,0 +1,87 @@
+// Copyright ©2017 The gonum Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+package f64
+
+import (
+	"fmt"
+	"testing"
+)
+
+var uniScal = []int64{1, 3, 10, 30, 1e2, 3e2, 1e3, 3e3, 1e4, 3e4}
+
+func BenchmarkScalUnitary(t *testing.B) {
+	tstName := "ScalUnitary"
+	for _, ln := range uniScal {
+		t.Run(fmt.Sprintf("%s-%d", tstName, ln), func(b *testing.B) {
+			b.SetBytes(64 * ln)
+			x := x[:ln]
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ScalUnitary(a, x)
+			}
+		})
+	}
+}
+
+func BenchmarkScalUnitaryTo(t *testing.B) {
+	tstName := "ScalUnitaryTo"
+	for _, ln := range uniScal {
+		t.Run(fmt.Sprintf("%s-%d", tstName, ln), func(b *testing.B) {
+			b.SetBytes(int64(64 * ln))
+			x, y := x[:ln], y[:ln]
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ScalUnitaryTo(y, a, x)
+			}
+		})
+	}
+}
+
+var incScal = []struct {
+	len uintptr
+	inc []int
+}{
+	{1, []int{1}},
+	{3, []int{1, 2, 4, 10}},
+	{10, []int{1, 2, 4, 10}},
+	{30, []int{1, 2, 4, 10}},
+	{1e2, []int{1, 2, 4, 10}},
+	{3e2, []int{1, 2, 4, 10}},
+	{1e3, []int{1, 2, 4, 10}},
+	{3e3, []int{1, 2, 4, 10}},
+	{1e4, []int{1, 2, 4, 10}},
+}
+
+func BenchmarkScalInc(t *testing.B) {
+	tstName := "ScalInc"
+	for _, tt := range incScal {
+		for _, inc := range tt.inc {
+			t.Run(fmt.Sprintf("%s-%d-inc(%d)", tstName, tt.len, inc), func(b *testing.B) {
+				b.SetBytes(int64(64 * tt.len))
+				tstInc := uintptr(inc)
+				for i := 0; i < b.N; i++ {
+					ScalInc(a, x, uintptr(tt.len), tstInc)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkScalIncTo(t *testing.B) {
+	tstName := "ScalIncTo"
+	for _, tt := range incScal {
+		for _, inc := range tt.inc {
+			t.Run(fmt.Sprintf("%s-%d-inc(%d)", tstName, tt.len, inc), func(b *testing.B) {
+				b.SetBytes(int64(64 * tt.len))
+				tstInc := uintptr(inc)
+				for i := 0; i < b.N; i++ {
+					ScalIncTo(z, tstInc, a, x, uintptr(tt.len), tstInc)
+				}
+			})
+		}
+	}
+}

--- a/asm/f64/bench_test.go
+++ b/asm/f64/bench_test.go
@@ -6,7 +6,10 @@
 
 package f64
 
-import "testing"
+import (
+	"math/rand"
+	"testing"
+)
 
 var (
 	a = float64(2)
@@ -286,3 +289,150 @@ func BenchmarkLF64AxpyIncToN100000IncM1(b *testing.B)  { benchaxpyincto(b, 10000
 func BenchmarkLF64AxpyIncToN100000IncM2(b *testing.B)  { benchaxpyincto(b, 100000, -2, naiveaxpyincto) }
 func BenchmarkLF64AxpyIncToN100000IncM4(b *testing.B)  { benchaxpyincto(b, 100000, -4, naiveaxpyincto) }
 func BenchmarkLF64AxpyIncToN100000IncM10(b *testing.B) { benchaxpyincto(b, 100000, -10, naiveaxpyincto) }
+
+// Scal* benchmarks
+func BenchmarkDscalUnitaryN1(b *testing.B)      { benchmarkDscalUnitary(b, 1) }
+func BenchmarkDscalUnitaryN2(b *testing.B)      { benchmarkDscalUnitary(b, 2) }
+func BenchmarkDscalUnitaryN3(b *testing.B)      { benchmarkDscalUnitary(b, 3) }
+func BenchmarkDscalUnitaryN4(b *testing.B)      { benchmarkDscalUnitary(b, 4) }
+func BenchmarkDscalUnitaryN10(b *testing.B)     { benchmarkDscalUnitary(b, 10) }
+func BenchmarkDscalUnitaryN100(b *testing.B)    { benchmarkDscalUnitary(b, 100) }
+func BenchmarkDscalUnitaryN1000(b *testing.B)   { benchmarkDscalUnitary(b, 1000) }
+func BenchmarkDscalUnitaryN10000(b *testing.B)  { benchmarkDscalUnitary(b, 10000) }
+func BenchmarkDscalUnitaryN100000(b *testing.B) { benchmarkDscalUnitary(b, 100000) }
+
+func benchmarkDscalUnitary(b *testing.B, n int) {
+	x := randomSlice(n, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i += 2 {
+		ScalUnitary(2, x)
+		ScalUnitary(0.5, x)
+	}
+	benchSink = x
+}
+
+func BenchmarkDscalUnitaryToN1(b *testing.B)      { benchmarkDscalUnitaryTo(b, 1) }
+func BenchmarkDscalUnitaryToN2(b *testing.B)      { benchmarkDscalUnitaryTo(b, 2) }
+func BenchmarkDscalUnitaryToN3(b *testing.B)      { benchmarkDscalUnitaryTo(b, 3) }
+func BenchmarkDscalUnitaryToN4(b *testing.B)      { benchmarkDscalUnitaryTo(b, 4) }
+func BenchmarkDscalUnitaryToN10(b *testing.B)     { benchmarkDscalUnitaryTo(b, 10) }
+func BenchmarkDscalUnitaryToN100(b *testing.B)    { benchmarkDscalUnitaryTo(b, 100) }
+func BenchmarkDscalUnitaryToN1000(b *testing.B)   { benchmarkDscalUnitaryTo(b, 1000) }
+func BenchmarkDscalUnitaryToN10000(b *testing.B)  { benchmarkDscalUnitaryTo(b, 10000) }
+func BenchmarkDscalUnitaryToN100000(b *testing.B) { benchmarkDscalUnitaryTo(b, 100000) }
+
+func benchmarkDscalUnitaryTo(b *testing.B, n int) {
+	x := randomSlice(n, 1)
+	dst := randomSlice(n, 1)
+	a := rand.Float64()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ScalUnitaryTo(dst, a, x)
+	}
+	benchSink = dst
+}
+
+func BenchmarkDscalUnitaryToXN1(b *testing.B)      { benchmarkDscalUnitaryToX(b, 1) }
+func BenchmarkDscalUnitaryToXN2(b *testing.B)      { benchmarkDscalUnitaryToX(b, 2) }
+func BenchmarkDscalUnitaryToXN3(b *testing.B)      { benchmarkDscalUnitaryToX(b, 3) }
+func BenchmarkDscalUnitaryToXN4(b *testing.B)      { benchmarkDscalUnitaryToX(b, 4) }
+func BenchmarkDscalUnitaryToXN10(b *testing.B)     { benchmarkDscalUnitaryToX(b, 10) }
+func BenchmarkDscalUnitaryToXN100(b *testing.B)    { benchmarkDscalUnitaryToX(b, 100) }
+func BenchmarkDscalUnitaryToXN1000(b *testing.B)   { benchmarkDscalUnitaryToX(b, 1000) }
+func BenchmarkDscalUnitaryToXN10000(b *testing.B)  { benchmarkDscalUnitaryToX(b, 10000) }
+func BenchmarkDscalUnitaryToXN100000(b *testing.B) { benchmarkDscalUnitaryToX(b, 100000) }
+
+func benchmarkDscalUnitaryToX(b *testing.B, n int) {
+	x := randomSlice(n, 1)
+	b.ResetTimer()
+	for i := 0; i < b.N; i += 2 {
+		ScalUnitaryTo(x, 2, x)
+		ScalUnitaryTo(x, 0.5, x)
+	}
+	benchSink = x
+}
+
+func BenchmarkDscalIncN1Inc1(b *testing.B) { benchmarkDscalInc(b, 1, 1) }
+
+func BenchmarkDscalIncN2Inc1(b *testing.B)  { benchmarkDscalInc(b, 2, 1) }
+func BenchmarkDscalIncN2Inc2(b *testing.B)  { benchmarkDscalInc(b, 2, 2) }
+func BenchmarkDscalIncN2Inc4(b *testing.B)  { benchmarkDscalInc(b, 2, 4) }
+func BenchmarkDscalIncN2Inc10(b *testing.B) { benchmarkDscalInc(b, 2, 10) }
+
+func BenchmarkDscalIncN3Inc1(b *testing.B)  { benchmarkDscalInc(b, 3, 1) }
+func BenchmarkDscalIncN3Inc2(b *testing.B)  { benchmarkDscalInc(b, 3, 2) }
+func BenchmarkDscalIncN3Inc4(b *testing.B)  { benchmarkDscalInc(b, 3, 4) }
+func BenchmarkDscalIncN3Inc10(b *testing.B) { benchmarkDscalInc(b, 3, 10) }
+
+func BenchmarkDscalIncN4Inc1(b *testing.B)  { benchmarkDscalInc(b, 4, 1) }
+func BenchmarkDscalIncN4Inc2(b *testing.B)  { benchmarkDscalInc(b, 4, 2) }
+func BenchmarkDscalIncN4Inc4(b *testing.B)  { benchmarkDscalInc(b, 4, 4) }
+func BenchmarkDscalIncN4Inc10(b *testing.B) { benchmarkDscalInc(b, 4, 10) }
+
+func BenchmarkDscalIncN10Inc1(b *testing.B)  { benchmarkDscalInc(b, 10, 1) }
+func BenchmarkDscalIncN10Inc2(b *testing.B)  { benchmarkDscalInc(b, 10, 2) }
+func BenchmarkDscalIncN10Inc4(b *testing.B)  { benchmarkDscalInc(b, 10, 4) }
+func BenchmarkDscalIncN10Inc10(b *testing.B) { benchmarkDscalInc(b, 10, 10) }
+
+func BenchmarkDscalIncN1000Inc1(b *testing.B)  { benchmarkDscalInc(b, 1000, 1) }
+func BenchmarkDscalIncN1000Inc2(b *testing.B)  { benchmarkDscalInc(b, 1000, 2) }
+func BenchmarkDscalIncN1000Inc4(b *testing.B)  { benchmarkDscalInc(b, 1000, 4) }
+func BenchmarkDscalIncN1000Inc10(b *testing.B) { benchmarkDscalInc(b, 1000, 10) }
+
+func BenchmarkDscalIncN100000Inc1(b *testing.B)  { benchmarkDscalInc(b, 100000, 1) }
+func BenchmarkDscalIncN100000Inc2(b *testing.B)  { benchmarkDscalInc(b, 100000, 2) }
+func BenchmarkDscalIncN100000Inc4(b *testing.B)  { benchmarkDscalInc(b, 100000, 4) }
+func BenchmarkDscalIncN100000Inc10(b *testing.B) { benchmarkDscalInc(b, 100000, 10) }
+
+func benchmarkDscalInc(b *testing.B, n, inc int) {
+	x := randomSlice(n, inc)
+	b.ResetTimer()
+	for i := 0; i < b.N; i += 2 {
+		ScalInc(2, x, uintptr(n), uintptr(inc))
+		ScalInc(0.5, x, uintptr(n), uintptr(inc))
+	}
+	benchSink = x
+}
+
+func BenchmarkDscalIncToN1Inc1(b *testing.B) { benchmarkDscalIncTo(b, 1, 1) }
+
+func BenchmarkDscalIncToN2Inc1(b *testing.B)  { benchmarkDscalIncTo(b, 2, 1) }
+func BenchmarkDscalIncToN2Inc2(b *testing.B)  { benchmarkDscalIncTo(b, 2, 2) }
+func BenchmarkDscalIncToN2Inc4(b *testing.B)  { benchmarkDscalIncTo(b, 2, 4) }
+func BenchmarkDscalIncToN2Inc10(b *testing.B) { benchmarkDscalIncTo(b, 2, 10) }
+
+func BenchmarkDscalIncToN3Inc1(b *testing.B)  { benchmarkDscalIncTo(b, 3, 1) }
+func BenchmarkDscalIncToN3Inc2(b *testing.B)  { benchmarkDscalIncTo(b, 3, 2) }
+func BenchmarkDscalIncToN3Inc4(b *testing.B)  { benchmarkDscalIncTo(b, 3, 4) }
+func BenchmarkDscalIncToN3Inc10(b *testing.B) { benchmarkDscalIncTo(b, 3, 10) }
+
+func BenchmarkDscalIncToN4Inc1(b *testing.B)  { benchmarkDscalIncTo(b, 4, 1) }
+func BenchmarkDscalIncToN4Inc2(b *testing.B)  { benchmarkDscalIncTo(b, 4, 2) }
+func BenchmarkDscalIncToN4Inc4(b *testing.B)  { benchmarkDscalIncTo(b, 4, 4) }
+func BenchmarkDscalIncToN4Inc10(b *testing.B) { benchmarkDscalIncTo(b, 4, 10) }
+
+func BenchmarkDscalIncToN10Inc1(b *testing.B)  { benchmarkDscalIncTo(b, 10, 1) }
+func BenchmarkDscalIncToN10Inc2(b *testing.B)  { benchmarkDscalIncTo(b, 10, 2) }
+func BenchmarkDscalIncToN10Inc4(b *testing.B)  { benchmarkDscalIncTo(b, 10, 4) }
+func BenchmarkDscalIncToN10Inc10(b *testing.B) { benchmarkDscalIncTo(b, 10, 10) }
+
+func BenchmarkDscalIncToN1000Inc1(b *testing.B)  { benchmarkDscalIncTo(b, 1000, 1) }
+func BenchmarkDscalIncToN1000Inc2(b *testing.B)  { benchmarkDscalIncTo(b, 1000, 2) }
+func BenchmarkDscalIncToN1000Inc4(b *testing.B)  { benchmarkDscalIncTo(b, 1000, 4) }
+func BenchmarkDscalIncToN1000Inc10(b *testing.B) { benchmarkDscalIncTo(b, 1000, 10) }
+
+func BenchmarkDscalIncToN100000Inc1(b *testing.B)  { benchmarkDscalIncTo(b, 100000, 1) }
+func BenchmarkDscalIncToN100000Inc2(b *testing.B)  { benchmarkDscalIncTo(b, 100000, 2) }
+func BenchmarkDscalIncToN100000Inc4(b *testing.B)  { benchmarkDscalIncTo(b, 100000, 4) }
+func BenchmarkDscalIncToN100000Inc10(b *testing.B) { benchmarkDscalIncTo(b, 100000, 10) }
+
+func benchmarkDscalIncTo(b *testing.B, n, inc int) {
+	x := randomSlice(n, inc)
+	dst := randomSlice(n, inc)
+	a := rand.Float64()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ScalIncTo(dst, uintptr(inc), a, x, uintptr(n), uintptr(inc))
+	}
+	benchSink = dst
+}

--- a/asm/f64/scalinc_amd64.s
+++ b/asm/f64/scalinc_amd64.s
@@ -38,52 +38,76 @@
 
 #include "textflag.h"
 
-#define X_PTR R8
-#define DST_PTR R9
-#define LEN DX
+#define X_PTR SI
+#define LEN CX
 #define TAIL BX
-#define INC_X R10
-#define INCx3_X R11
-#define ALPHA X7
+#define INC_X R8
+#define INCx3_X R9
+#define ALPHA X0
 #define ALPHA_2 X1
 
 // func ScalInc(alpha float64, x []float64, n, incX uintptr)
 TEXT ·ScalInc(SB), NOSPLIT, $0
-	MOVHPD alpha+0(FP), ALPHA
-	MOVLPD alpha+0(FP), ALPHA
-	MOVQ   x+8(FP), X_PTR
-	MOVQ   n+32(FP), LEN
-	MOVQ   incX+40(FP), INC_X
+	MOVSD alpha+0(FP), ALPHA  // ALPHA = alpha
+	MOVQ  x_base+8(FP), X_PTR // X_PTR = &x
+	MOVQ  incX+40(FP), INC_X  // INC_X = incX
+	SHLQ  $3, INC_X           // INC_X *= sizeof(float64)
+	MOVQ  n+32(FP), LEN       // LEN = n
+	CMPQ  LEN, $0
+	JE    end                 // if LEN == 0 { return }
 
-	MOVQ $0, SI
-	MOVQ INC_X, AX // nextX = incX
-	SHLQ $1, INC_X // incX *= 2
+	MOVQ LEN, TAIL
+	ANDQ $3, TAIL   // TAIL = LEN % 4
+	SHRQ $2, LEN    // LEN = floor( LEN / 4 )
+	JZ   tail_start // if LEN == 0 { goto tail_start }
 
-	SUBQ $2, LEN // n -= 2
-	JL   tail    // if n < 0
+	MOVUPS ALPHA, ALPHA_2            // ALPHA_2 = ALPHA for pipelining
+	LEAQ   (INC_X)(INC_X*2), INCx3_X // INCx3_X = INC_X * 3
 
-loop:
-	// x[i] *= alpha unrolled 2x.
-	MOVHPD 0(X_PTR)(SI*8), X0
-	MOVLPD 0(X_PTR)(AX*8), X0
-	MULPD  ALPHA, X0
-	MOVHPD X0, 0(X_PTR)(SI*8)
-	MOVLPD X0, 0(X_PTR)(AX*8)
+loop:  // do { // x[i] *= alpha unrolled 4x.
+	MOVSD (X_PTR), X2            // X_i = x[i]
+	MOVSD (X_PTR)(INC_X*1), X3
+	MOVSD (X_PTR)(INC_X*2), X4
+	MOVSD (X_PTR)(INCx3_X*1), X5
 
-	ADDQ INC_X, SI // ix += incX
-	ADDQ INC_X, AX // nextX += incX
+	MULSD ALPHA, X2   // X_i *= a
+	MULSD ALPHA_2, X3
+	MULSD ALPHA, X4
+	MULSD ALPHA_2, X5
 
-	SUBQ $2, LEN // n -= 2
-	JGE  loop    // if n >= 0 goto loop
+	MOVSD X2, (X_PTR)            // x[i] = X_i
+	MOVSD X3, (X_PTR)(INC_X*1)
+	MOVSD X4, (X_PTR)(INC_X*2)
+	MOVSD X5, (X_PTR)(INCx3_X*1)
 
-tail:
-	ADDQ $2, LEN // n += 2
-	JLE  end     // if n <= 0
+	LEAQ (X_PTR)(INC_X*4), X_PTR // X_PTR = &(X_PTR[incX*4])
+	DECQ LEN
+	JNZ  loop                    // } while --LEN > 0
+	CMPQ TAIL, $0
+	JE   end                     // if TAIL == 0 { return }
 
-	// x[i] *= alpha for the last iteration if n is odd.
-	MOVSD 0(X_PTR)(SI*8), X0
-	MULSD ALPHA, X0
-	MOVSD X0, 0(X_PTR)(SI*8)
+tail_start: // Reset loop registers
+	MOVQ TAIL, LEN // Loop counter: LEN = TAIL
+	SHRQ $1, LEN   // LEN = floor( LEN / 2 )
+	JZ   tail_one
+
+tail_two: // do {
+	MOVSD (X_PTR), X2          // X_i = x[i]
+	MOVSD (X_PTR)(INC_X*1), X3
+	MULSD ALPHA, X2            // X_i *= a
+	MULSD ALPHA, X3
+	MOVSD X2, (X_PTR)          // x[i] = X_i
+	MOVSD X3, (X_PTR)(INC_X*1)
+
+	LEAQ (X_PTR)(INC_X*2), X_PTR // X_PTR = &(X_PTR[incX*2])
+
+	ANDQ $1, TAIL
+	JZ   end
+
+tail_one:
+	MOVSD (X_PTR), X2 // X_i = x[i]
+	MULSD ALPHA, X2   // X_i *= ALPHA
+	MOVSD X2, (X_PTR) // x[i] = X_i
 
 end:
 	RET

--- a/asm/f64/scalincto_amd64.s
+++ b/asm/f64/scalincto_amd64.s
@@ -38,61 +38,85 @@
 
 #include "textflag.h"
 
-#define X_PTR R8
-#define DST_PTR R9
-#define LEN DX
+#define X_PTR SI
+#define DST_PTR DI
+#define LEN CX
 #define TAIL BX
-#define INC_X R10
-#define INCx3_X R11
-#define INC_DST R11
+#define INC_X R8
+#define INCx3_X R9
+#define INC_DST R10
 #define INCx3_DST R11
-#define ALPHA X7
+#define ALPHA X0
 #define ALPHA_2 X1
 
 // func ScalIncTo(dst []float64, incDst uintptr, alpha float64, x []float64, n, incX uintptr)
 TEXT ·ScalIncTo(SB), NOSPLIT, $0
-	MOVQ   dst+0(FP), DST_PTR
-	MOVQ   incDst+24(FP), INC_DST
-	MOVHPD alpha+32(FP), ALPHA
-	MOVLPD alpha+32(FP), ALPHA
-	MOVQ   x+40(FP), X_PTR
-	MOVQ   n+64(FP), LEN
-	MOVQ   incX+72(FP), INC_X
+	MOVQ  dst_base+0(FP), DST_PTR // DST_PTR = &dst
+	MOVQ  incDst+24(FP), INC_DST  // INC_DST = incDst
+	SHLQ  $3, INC_DST             // INC_DST *= sizeof(float64)
+	MOVSD alpha+32(FP), ALPHA     // ALPHA = alpha
+	MOVQ  x_base+40(FP), X_PTR    // X_PTR = &x
+	MOVQ  n+64(FP), LEN           // LEN = n
+	MOVQ  incX+72(FP), INC_X      // INC_X = incX
+	SHLQ  $3, INC_X               // INC_X *= sizeof(float64)
+	CMPQ  LEN, $0
+	JE    end                     // if LEN == 0 { return }
 
-	MOVQ $0, SI
-	MOVQ $0, DI
-	MOVQ INC_X, AX   // nextX = incX
-	MOVQ INC_DST, BX // nextDst = incDst
-	SHLQ $1, INC_X   // incX *= 2
-	SHLQ $1, INC_DST // incDst *= 2
+	MOVQ LEN, TAIL
+	ANDQ $3, TAIL   // TAIL = LEN % 4
+	SHRQ $2, LEN    // LEN = floor( LEN / 4 )
+	JZ   tail_start // if LEN == 0 { goto tail_start }
 
-	SUBQ $2, LEN // n -= 2
-	JL   tail    // if n < 0
+	MOVUPS ALPHA, ALPHA_2                  // ALPHA_2 = ALPHA for pipelining
+	LEAQ   (INC_X)(INC_X*2), INCx3_X       // INCx3_X = INC_X * 3
+	LEAQ   (INC_DST)(INC_DST*2), INCx3_DST // INCx3_DST = INC_DST * 3
 
-loop:
-	// dst[i] = alpha * x[i] unrolled 2x.
-	MOVHPD 0(X_PTR)(SI*8), X0
-	MOVLPD 0(X_PTR)(AX*8), X0
-	MULPD  ALPHA, X0
-	MOVHPD X0, 0(DST_PTR)(DI*8)
-	MOVLPD X0, 0(DST_PTR)(BX*8)
+loop:  // do { // x[i] *= alpha unrolled 4x.
+	MOVSD (X_PTR), X2            // X_i = x[i]
+	MOVSD (X_PTR)(INC_X*1), X3
+	MOVSD (X_PTR)(INC_X*2), X4
+	MOVSD (X_PTR)(INCx3_X*1), X5
 
-	ADDQ INC_X, SI   // ix += incX
-	ADDQ INC_X, AX   // nextX += incX
-	ADDQ INC_DST, DI // idst += incDst
-	ADDQ INC_DST, BX // nextDst += incDst
+	MULSD ALPHA, X2   // X_i *= a
+	MULSD ALPHA_2, X3
+	MULSD ALPHA, X4
+	MULSD ALPHA_2, X5
 
-	SUBQ $2, LEN // n -= 2
-	JGE  loop    // if n >= 0 goto loop
+	MOVSD X2, (DST_PTR)              // dst[i] = X_i
+	MOVSD X3, (DST_PTR)(INC_DST*1)
+	MOVSD X4, (DST_PTR)(INC_DST*2)
+	MOVSD X5, (DST_PTR)(INCx3_DST*1)
 
-tail:
-	ADDQ $2, LEN // n += 2
-	JLE  end     // if n <= 0
+	LEAQ (X_PTR)(INC_X*4), X_PTR       // X_PTR = &(X_PTR[incX*4])
+	LEAQ (DST_PTR)(INC_DST*4), DST_PTR // DST_PTR = &(DST_PTR[incDst*4])
+	DECQ LEN
+	JNZ  loop                          // } while --LEN > 0
+	CMPQ TAIL, $0
+	JE   end                           // if TAIL == 0 { return }
 
-	// dst[i] = alpha * x[i] for the last iteration if n is odd.
-	MOVSD 0(X_PTR)(SI*8), X0
-	MULSD ALPHA, X0
-	MOVSD X0, 0(DST_PTR)(DI*8)
+tail_start: // Reset loop registers
+	MOVQ TAIL, LEN // Loop counter: LEN = TAIL
+	SHRQ $1, LEN   // LEN = floor( LEN / 2 )
+	JZ   tail_one
+
+tail_two:
+	MOVSD (X_PTR), X2              // X_i = x[i]
+	MOVSD (X_PTR)(INC_X*1), X3
+	MULSD ALPHA, X2                // X_i *= a
+	MULSD ALPHA, X3
+	MOVSD X2, (DST_PTR)            // dst[i] = X_i
+	MOVSD X3, (DST_PTR)(INC_DST*1)
+
+	LEAQ (X_PTR)(INC_X*2), X_PTR       // X_PTR = &(X_PTR[incX*2])
+	LEAQ (DST_PTR)(INC_DST*2), DST_PTR // DST_PTR = &(DST_PTR[incDst*2])
+
+	ANDQ $1, TAIL
+	JZ   end
+
+tail_one:
+	MOVSD (X_PTR), X2   // X_i = x[i]
+	MULSD ALPHA, X2     // X_i *= ALPHA
+	MOVSD X2, (DST_PTR) // x[i] = X_i
 
 end:
 	RET

--- a/asm/f64/scalunitaryto_amd64.s
+++ b/asm/f64/scalunitaryto_amd64.s
@@ -38,53 +38,76 @@
 
 #include "textflag.h"
 
-#define X_PTR R8
-#define DST_PTR R9
-#define IDX SI
-#define LEN DI
+#define MOVDDUP_ALPHA    LONG $0x44120FF2; WORD $0x2024 // @ MOVDDUP 32(SP), X0  /*XMM0, 32[RSP]*/
+
+#define X_PTR SI
+#define DST_PTR DI
+#define IDX AX
+#define LEN CX
 #define TAIL BX
-#define ALPHA X7
+#define ALPHA X0
 #define ALPHA_2 X1
 
 // func ScalUnitaryTo(dst []float64, alpha float64, x []float64)
 // This function assumes len(dst) >= len(x).
 TEXT ·ScalUnitaryTo(SB), NOSPLIT, $0
-	MOVQ   dst+0(FP), DST_PTR
-	MOVHPD alpha+24(FP), ALPHA
-	MOVLPD alpha+24(FP), ALPHA
-	MOVQ   x+32(FP), X_PTR
-	MOVQ   x_len+40(FP), LEN   // n = len(x)
+	MOVQ x_base+32(FP), X_PTR    // X_PTR = &x
+	MOVQ dst_base+0(FP), DST_PTR // DST_PTR = &dst
+	MOVDDUP_ALPHA                // ALPHA = { alpha, alpha }
+	MOVQ x_len+40(FP), LEN       // LEN = len(x)
+	CMPQ LEN, $0
+	JE   end                     // if LEN == 0 { return }
 
-	MOVQ $0, IDX // i = 0
-	SUBQ $4, LEN // n -= 4
-	JL   tail    // if n < 0 goto tail
+	XORQ IDX, IDX   // IDX = 0
+	MOVQ LEN, TAIL
+	ANDQ $7, TAIL   // TAIL = LEN % 8
+	SHRQ $3, LEN    // LEN = floor( LEN / 8 )
+	JZ   tail_start // if LEN == 0 { goto tail_start }
 
-loop:
-	// dst[i] = alpha * x[i] unrolled 4x.
-	MOVUPD 0(X_PTR)(IDX*8), X0
-	MOVUPD 16(X_PTR)(IDX*8), X1
-	MULPD  ALPHA, X0
-	MULPD  ALPHA, X1
-	MOVUPD X0, 0(DST_PTR)(IDX*8)
-	MOVUPD X1, 16(DST_PTR)(IDX*8)
+	MOVUPS ALPHA, ALPHA_2 // ALPHA_2 = ALPHA for pipelining
 
-	ADDQ $4, IDX // i += 4
-	SUBQ $4, LEN // n -= 4
-	JGE  loop    // if n >= 0 goto loop
+loop:  // do { // dst[i] = alpha * x[i] unrolled 8x.
+	MOVUPS (X_PTR)(IDX*8), X2   // X_i = x[i]
+	MOVUPS 16(X_PTR)(IDX*8), X3
+	MOVUPS 32(X_PTR)(IDX*8), X4
+	MOVUPS 48(X_PTR)(IDX*8), X5
 
-tail:
-	ADDQ $4, LEN // n += 4
-	JZ   end     // if n == 0 goto end
+	MULPD ALPHA, X2   // X_i *= ALPHA
+	MULPD ALPHA_2, X3
+	MULPD ALPHA, X4
+	MULPD ALPHA_2, X5
 
-onemore:
-	// dst[i] = alpha * x[i] for the remaining 1-3 elements.
-	MOVSD 0(X_PTR)(IDX*8), X0
-	MULSD ALPHA, X0
-	MOVSD X0, 0(DST_PTR)(IDX*8)
+	MOVUPS X2, (DST_PTR)(IDX*8)   // dst[i] = X_i
+	MOVUPS X3, 16(DST_PTR)(IDX*8)
+	MOVUPS X4, 32(DST_PTR)(IDX*8)
+	MOVUPS X5, 48(DST_PTR)(IDX*8)
 
-	ADDQ $1, IDX // i++
-	SUBQ $1, LEN // n--
-	JNZ  onemore // if n != 0 goto onemore
+	ADDQ $8, IDX  // i += 8
+	DECQ LEN
+	JNZ  loop     // while --LEN > 0
+	CMPQ TAIL, $0
+	JE   end      // if TAIL == 0 { return }
+
+tail_start: // Reset loop counters
+	MOVQ TAIL, LEN // Loop counter: LEN = TAIL
+	SHRQ $1, LEN   // LEN = floor( TAIL / 2 )
+	JZ   tail_one  // if LEN == 0 { goto tail_one }
+
+tail_two: // do {
+	MOVUPS (X_PTR)(IDX*8), X2   // X_i = x[i]
+	MULPD  ALPHA, X2            // X_i *= ALPHA
+	MOVUPS X2, (DST_PTR)(IDX*8) // dst[i] = X_i
+	ADDQ   $2, IDX              // i += 2
+	DECQ   LEN
+	JNZ    tail_two             // while --LEN > 0
+
+	ANDQ $1, TAIL
+	JZ   end      // if TAIL == 0 { return }
+
+tail_one:
+	MOVSD (X_PTR)(IDX*8), X2   // X_i = x[i]
+	MULSD ALPHA, X2            // X_i *= ALPHA
+	MOVSD X2, (DST_PTR)(IDX*8) // dst[i] = X_i
 
 end:
 	RET


### PR DESCRIPTION
This depends on updates in gonum/internal#52

Cleaned up and widened loops in scal* assembly functions.  

<details><summary>Benchmarks vs old asm</summary>

<table class='benchstat oldnew'>
<tr class='configs'><th><th>Old asm<th>New asm


<tbody>
<tr><th><th colspan='2' class='metric'>time/op<th>delta
<tr class='unchanged'><td>ScalUnitary/ScalUnitary-1-12<td>2.89ns ± 7%<td>2.92ns ±13%<td class='nodelta'>~<td class='note'>(p=0.862 n=19&#43;20)
<tr class='better'><td>ScalUnitary/ScalUnitary-2-12<td>3.03ns ± 1%<td>2.77ns ± 3%<td class='delta'>−8.49%<td class='note'>(p=0.000 n=17&#43;17)
<tr class='better'><td>ScalUnitary/ScalUnitary-3-12<td>3.88ns ±12%<td>3.07ns ± 1%<td class='delta'>−20.74%<td class='note'>(p=0.000 n=20&#43;16)
<tr class='worse'><td>ScalUnitary/ScalUnitary-4-12<td>2.87ns ±13%<td>3.41ns ±10%<td class='delta'>&#43;18.68%<td class='note'>(p=0.000 n=19&#43;19)
<tr class='worse'><td>ScalUnitary/ScalUnitary-5-12<td>3.48ns ±19%<td>3.52ns ± 6%<td class='delta'>&#43;1.29%<td class='note'>(p=0.028 n=20&#43;18)
<tr class='better'><td>ScalUnitary/ScalUnitary-10-12<td>4.75ns ± 3%<td>4.39ns ± 5%<td class='delta'>−7.56%<td class='note'>(p=0.000 n=16&#43;18)
<tr class='better'><td>ScalUnitary/ScalUnitary-100-12<td>20.9ns ± 2%<td>17.2ns ± 3%<td class='delta'>−17.57%<td class='note'>(p=0.000 n=16&#43;17)
<tr class='better'><td>ScalUnitary/ScalUnitary-500-12<td>79.4ns ± 0%<td>71.8ns ± 9%<td class='delta'>−9.53%<td class='note'>(p=0.000 n=16&#43;16)
<tr class='better'><td>ScalUnitary/ScalUnitary-1000-12<td>145ns ± 2%<td>142ns ±14%<td class='delta'>−2.08%<td class='note'>(p=0.031 n=18&#43;20)
<tr class='better'><td>ScalUnitary/ScalUnitary-5000-12<td>1.04µs ± 0%<td>1.03µs ± 1%<td class='delta'>−0.65%<td class='note'>(p=0.000 n=16&#43;16)
<tr class='better'><td>ScalUnitary/ScalUnitary-10000-12<td>2.07µs ± 0%<td>2.05µs ± 0%<td class='delta'>−0.82%<td class='note'>(p=0.000 n=16&#43;17)
<tr class='unchanged'><td>ScalUnitary/ScalUnitary-50000-12<td>15.4µs ± 3%<td>15.6µs ± 4%<td class='nodelta'>~<td class='note'>(p=0.178 n=16&#43;18)
<tr class='unchanged'><td>ScalUnitaryTo/ScalUnitaryTo-1-12<td>3.02ns ± 4%<td>3.09ns ±14%<td class='nodelta'>~<td class='note'>(p=0.840 n=9&#43;9)
<tr class='better'><td>ScalUnitaryTo/ScalUnitaryTo-2-12<td>3.57ns ± 7%<td>3.12ns ± 2%<td class='delta'>−12.65%<td class='note'>(p=0.000 n=10&#43;9)
<tr class='better'><td>ScalUnitaryTo/ScalUnitaryTo-3-12<td>4.07ns ± 1%<td>3.57ns ± 1%<td class='delta'>−12.23%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='worse'><td>ScalUnitaryTo/ScalUnitaryTo-4-12<td>3.33ns ± 0%<td>4.35ns ± 2%<td class='delta'>&#43;30.76%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='worse'><td>ScalUnitaryTo/ScalUnitaryTo-5-12<td>4.05ns ± 0%<td>4.26ns ± 9%<td class='delta'>&#43;5.14%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='unchanged'><td>ScalUnitaryTo/ScalUnitaryTo-10-12<td>5.38ns ± 8%<td>5.23ns ±26%<td class='nodelta'>~<td class='note'>(p=0.102 n=10&#43;10)
<tr class='worse'><td>ScalUnitaryTo/ScalUnitaryTo-100-12<td>17.9ns ± 0%<td>18.1ns ± 2%<td class='delta'>&#43;1.19%<td class='note'>(p=0.001 n=8&#43;8)
<tr class='better'><td>ScalUnitaryTo/ScalUnitaryTo-500-12<td>76.8ns ±10%<td>71.8ns ± 2%<td class='delta'>−6.54%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>ScalUnitaryTo/ScalUnitaryTo-1000-12<td>140ns ± 2%<td>134ns ± 1%<td class='delta'>−4.63%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='better'><td>ScalUnitaryTo/ScalUnitaryTo-5000-12<td>1.35µs ±15%<td>1.27µs ± 1%<td class='delta'>−6.07%<td class='note'>(p=0.011 n=10&#43;9)
<tr class='unchanged'><td>ScalUnitaryTo/ScalUnitaryTo-10000-12<td>2.80µs ±20%<td>2.63µs ± 7%<td class='nodelta'>~<td class='note'>(p=0.424 n=10&#43;10)
<tr class='unchanged'><td>ScalUnitaryTo/ScalUnitaryTo-50000-12<td>23.0µs ± 0%<td>22.9µs ± 0%<td class='nodelta'>~<td class='note'>(p=0.200 n=9&#43;8)
<tr class='worse'><td>ScalInc/ScalInc-1-inc(1)-12<td>2.84ns ± 1%<td>2.98ns ± 1%<td class='delta'>&#43;4.66%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='better'><td>ScalInc/ScalInc-2-inc(1)-12<td>3.52ns ± 1%<td>3.41ns ± 1%<td class='delta'>−2.95%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='better'><td>ScalInc/ScalInc-2-inc(2)-12<td>3.56ns ± 7%<td>3.42ns ± 4%<td class='delta'>−4.02%<td class='note'>(p=0.001 n=9&#43;9)
<tr class='unchanged'><td>ScalInc/ScalInc-2-inc(4)-12<td>3.55ns ± 2%<td>3.54ns ±10%<td class='nodelta'>~<td class='note'>(p=0.389 n=9&#43;10)
<tr class='better'><td>ScalInc/ScalInc-2-inc(10)-12<td>3.50ns ± 1%<td>3.41ns ± 1%<td class='delta'>−2.79%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='unchanged'><td>ScalInc/ScalInc-3-inc(1)-12<td>4.03ns ± 8%<td>3.95ns ±11%<td class='nodelta'>~<td class='note'>(p=0.238 n=10&#43;10)
<tr class='better'><td>ScalInc/ScalInc-3-inc(2)-12<td>3.81ns ± 0%<td>3.75ns ± 0%<td class='delta'>−1.66%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='better'><td>ScalInc/ScalInc-3-inc(4)-12<td>3.95ns ±10%<td>3.75ns ± 1%<td class='delta'>−5.09%<td class='note'>(p=0.000 n=10&#43;8)
<tr class='unchanged'><td>ScalInc/ScalInc-3-inc(10)-12<td>3.82ns ± 0%<td>3.81ns ± 7%<td class='nodelta'>~<td class='note'>(p=0.053 n=8&#43;9)
<tr class='better'><td>ScalInc/ScalInc-4-inc(1)-12<td>4.54ns ± 4%<td>4.23ns ± 5%<td class='delta'>−6.83%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='better'><td>ScalInc/ScalInc-4-inc(2)-12<td>4.54ns ± 2%<td>4.21ns ± 2%<td class='delta'>−7.32%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>ScalInc/ScalInc-4-inc(4)-12<td>4.56ns ± 4%<td>4.25ns ± 5%<td class='delta'>−6.85%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>ScalInc/ScalInc-4-inc(10)-12<td>4.50ns ± 0%<td>4.19ns ± 1%<td class='delta'>−6.97%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='better'><td>ScalInc/ScalInc-5-inc(1)-12<td>5.13ns ± 1%<td>4.96ns ± 0%<td class='delta'>−3.24%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='better'><td>ScalInc/ScalInc-5-inc(2)-12<td>5.37ns ±11%<td>4.98ns ± 1%<td class='delta'>−7.35%<td class='note'>(p=0.000 n=10&#43;8)
<tr class='better'><td>ScalInc/ScalInc-5-inc(4)-12<td>5.22ns ± 3%<td>5.07ns ± 5%<td class='delta'>−2.85%<td class='note'>(p=0.038 n=9&#43;9)
<tr class='unchanged'><td>ScalInc/ScalInc-5-inc(10)-12<td>5.11ns ± 0%<td>5.20ns ± 9%<td class='nodelta'>~<td class='note'>(p=0.712 n=9&#43;9)
<tr class='worse'><td>ScalInc/ScalInc-10-inc(1)-12<td>8.01ns ± 4%<td>8.85ns ±14%<td class='delta'>&#43;10.49%<td class='note'>(p=0.005 n=8&#43;10)
<tr class='unchanged'><td>ScalInc/ScalInc-10-inc(2)-12<td>8.35ns ±22%<td>8.10ns ± 1%<td class='nodelta'>~<td class='note'>(p=0.243 n=9&#43;9)
<tr class='unchanged'><td>ScalInc/ScalInc-10-inc(4)-12<td>9.10ns ±14%<td>8.13ns ± 4%<td class='nodelta'>~<td class='note'>(p=0.479 n=10&#43;9)
<tr class='unchanged'><td>ScalInc/ScalInc-10-inc(10)-12<td>8.70ns ±16%<td>8.12ns ± 0%<td class='nodelta'>~<td class='note'>(p=0.501 n=10&#43;8)
<tr class='better'><td>ScalInc/ScalInc-500-inc(1)-12<td>457ns ±17%<td>133ns ± 2%<td class='delta'>−70.97%<td class='note'>(p=0.000 n=10&#43;8)
<tr class='better'><td>ScalInc/ScalInc-500-inc(2)-12<td>435ns ± 3%<td>136ns ± 9%<td class='delta'>−68.79%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='better'><td>ScalInc/ScalInc-500-inc(4)-12<td>444ns ±13%<td>139ns ±15%<td class='delta'>−68.75%<td class='note'>(p=0.000 n=9&#43;10)
<tr class='better'><td>ScalInc/ScalInc-500-inc(10)-12<td>447ns ± 8%<td>152ns ± 1%<td class='delta'>−66.12%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>ScalInc/ScalInc-1000-inc(1)-12<td>924ns ±17%<td>259ns ± 1%<td class='delta'>−72.01%<td class='note'>(p=0.000 n=10&#43;9)
<tr class='better'><td>ScalInc/ScalInc-1000-inc(2)-12<td>940ns ±12%<td>267ns ± 8%<td class='delta'>−71.55%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='better'><td>ScalInc/ScalInc-1000-inc(4)-12<td>946ns ±22%<td>285ns ± 9%<td class='delta'>−69.87%<td class='note'>(p=0.000 n=10&#43;9)
<tr class='worse'><td>ScalInc/ScalInc-1000-inc(10)-12<td>1.61µs ± 0%<td>1.63µs ± 0%<td class='delta'>&#43;1.15%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='better'><td>ScalInc/ScalInc-10000-inc(1)-12<td>8.76µs ± 0%<td>3.07µs ± 0%<td class='delta'>−64.98%<td class='note'>(p=0.000 n=9&#43;10)
<tr class='better'><td>ScalInc/ScalInc-10000-inc(2)-12<td>9.32µs ± 9%<td>4.46µs ±19%<td class='delta'>−52.11%<td class='note'>(p=0.000 n=10&#43;10)
<tr class='unchanged'><td>ScalInc/ScalInc-10000-inc(4)-12<td>11.1µs ± 4%<td>11.1µs ±12%<td class='nodelta'>~<td class='note'>(p=0.604 n=9&#43;10)
<tr class='unchanged'><td>ScalInc/ScalInc-10000-inc(10)-12<td>24.3µs ± 9%<td>24.8µs ±17%<td class='nodelta'>~<td class='note'>(p=0.725 n=10&#43;10)
<tr class='worse'><td>ScalIncTo/ScalIncTo-1-inc(1)-12<td>3.77ns ± 3%<td>3.93ns ±10%<td class='delta'>&#43;4.04%<td class='note'>(p=0.003 n=9&#43;10)
<tr class='better'><td>ScalIncTo/ScalIncTo-2-inc(1)-12<td>4.56ns ± 4%<td>4.49ns ± 5%<td class='delta'>−1.65%<td class='note'>(p=0.023 n=9&#43;10)
<tr class='better'><td>ScalIncTo/ScalIncTo-2-inc(2)-12<td>4.52ns ± 1%<td>4.43ns ± 0%<td class='delta'>−2.09%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-2-inc(4)-12<td>4.53ns ± 1%<td>4.42ns ± 0%<td class='delta'>−2.35%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-2-inc(10)-12<td>4.84ns ±23%<td>4.43ns ± 1%<td class='delta'>−8.43%<td class='note'>(p=0.000 n=10&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-3-inc(1)-12<td>4.99ns ± 4%<td>4.76ns ± 0%<td class='delta'>−4.68%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-3-inc(2)-12<td>4.97ns ± 1%<td>4.77ns ± 1%<td class='delta'>−4.19%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='unchanged'><td>ScalIncTo/ScalIncTo-3-inc(4)-12<td>4.97ns ± 1%<td>4.89ns ± 9%<td class='nodelta'>~<td class='note'>(p=0.163 n=8&#43;10)
<tr class='better'><td>ScalIncTo/ScalIncTo-3-inc(10)-12<td>5.08ns ±12%<td>4.76ns ± 0%<td class='delta'>−6.30%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-4-inc(1)-12<td>5.76ns ± 4%<td>5.19ns ± 5%<td class='delta'>−9.87%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-4-inc(2)-12<td>5.76ns ± 3%<td>5.13ns ± 0%<td class='delta'>−11.01%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-4-inc(4)-12<td>6.02ns ±14%<td>5.13ns ± 1%<td class='delta'>−14.73%<td class='note'>(p=0.000 n=10&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-4-inc(10)-12<td>5.72ns ± 1%<td>5.19ns ± 3%<td class='delta'>−9.15%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-5-inc(1)-12<td>6.08ns ± 1%<td>5.60ns ± 0%<td class='delta'>−8.01%<td class='note'>(p=0.000 n=8&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-5-inc(2)-12<td>6.12ns ± 3%<td>5.72ns ± 3%<td class='delta'>−6.48%<td class='note'>(p=0.000 n=8&#43;10)
<tr class='better'><td>ScalIncTo/ScalIncTo-5-inc(4)-12<td>6.07ns ± 0%<td>5.64ns ± 2%<td class='delta'>−7.17%<td class='note'>(p=0.000 n=9&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-5-inc(10)-12<td>6.07ns ± 0%<td>5.67ns ± 2%<td class='delta'>−6.67%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='unchanged'><td>ScalIncTo/ScalIncTo-10-inc(1)-12<td>9.54ns ±16%<td>9.26ns ± 0%<td class='nodelta'>~<td class='note'>(p=0.496 n=10&#43;8)
<tr class='worse'><td>ScalIncTo/ScalIncTo-10-inc(2)-12<td>9.02ns ± 1%<td>10.06ns ±22%<td class='delta'>&#43;11.63%<td class='note'>(p=0.000 n=8&#43;10)
<tr class='worse'><td>ScalIncTo/ScalIncTo-10-inc(4)-12<td>9.06ns ± 2%<td>9.28ns ± 1%<td class='delta'>&#43;2.42%<td class='note'>(p=0.001 n=9&#43;8)
<tr class='unchanged'><td>ScalIncTo/ScalIncTo-10-inc(10)-12<td>9.63ns ±11%<td>9.27ns ± 1%<td class='nodelta'>~<td class='note'>(p=0.498 n=10&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-500-inc(1)-12<td>457ns ±13%<td>136ns ± 1%<td class='delta'>−70.34%<td class='note'>(p=0.000 n=10&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-500-inc(2)-12<td>436ns ± 0%<td>135ns ± 0%<td class='delta'>−69.06%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-500-inc(4)-12<td>440ns ± 0%<td>219ns ± 4%<td class='delta'>−50.23%<td class='note'>(p=0.000 n=8&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-500-inc(10)-12<td>1.00µs ± 0%<td>1.00µs ± 0%<td class='delta'>−0.24%<td class='note'>(p=0.012 n=9&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-1000-inc(1)-12<td>875ns ± 0%<td>261ns ± 0%<td class='delta'>−70.16%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-1000-inc(2)-12<td>878ns ± 0%<td>362ns ± 8%<td class='delta'>−58.72%<td class='note'>(p=0.000 n=8&#43;10)
<tr class='better'><td>ScalIncTo/ScalIncTo-1000-inc(4)-12<td>1.01µs ± 1%<td>1.01µs ± 1%<td class='delta'>−0.83%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-1000-inc(10)-12<td>2.09µs ± 9%<td>2.03µs ± 4%<td class='delta'>−2.89%<td class='note'>(p=0.013 n=10&#43;9)
<tr class='better'><td>ScalIncTo/ScalIncTo-10000-inc(1)-12<td>8.77µs ± 0%<td>3.35µs ± 1%<td class='delta'>−61.81%<td class='note'>(p=0.000 n=9&#43;8)
<tr class='better'><td>ScalIncTo/ScalIncTo-10000-inc(2)-12<td>9.16µs ± 1%<td>7.16µs ± 6%<td class='delta'>−21.90%<td class='note'>(p=0.000 n=9&#43;10)
<tr class='unchanged'><td>ScalIncTo/ScalIncTo-10000-inc(4)-12<td>19.0µs ±11%<td>18.7µs ± 8%<td class='nodelta'>~<td class='note'>(p=0.529 n=10&#43;10)
<tr class='unchanged'><td>ScalIncTo/ScalIncTo-10000-inc(10)-12<td>38.5µs ± 0%<td>38.5µs ± 1%<td class='nodelta'>~<td class='note'>(p=0.624 n=8&#43;8)
<tr><td>&nbsp;
</tbody>

</table>

</details>
